### PR TITLE
Updating the biochemistry pages to use reversibility instead of direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,21 +3,15 @@
 
 ## Requirements
 - node (https://nodejs.org/)
-- bower `npm install -g bower`
-
-
+(it is recommended that you use nvm to manage versions of node and the package manager npm)
 
 ## Local Installation
 
 ```
 git clone --recursive https://github.com/modelseed/modelseed-ui.git modelseed-ui
 cd modelseed-ui
-bower install
+npm install
 ```
-
-Notes:
-- `bower install` installs some third-party (front-end) dependencies
-
 
 Now point your favorite webserver at `modelseed-ui` and you are ready to go!
 

--- a/app/ctrls/ms-ctrls.js
+++ b/app/ctrls/ms-ctrls.js
@@ -258,7 +258,7 @@ function($s, Biochem, $state, $stateParams, MS, Session) {
     var rxn_sFields = ['id', 'name', 'status', 'synonyms', 'aliases', 'pathways', 'stoichiometry', 'notes'];
     $s.rxnOpts = Session.getOpts($state, 'rxns') ||
                   {query: '', limit: 25, offset: 0, sort: {field: 'id'}, core: 'reactions', searchFields: rxn_sFields,
-                  visible: ['name', 'id', 'definition', 'deltag', 'deltagerr', 'direction', 'stoichiometry', 'status',
+                  visible: ['name', 'id', 'definition', 'deltag', 'deltagerr', 'reversibility', 'stoichiometry', 'status',
                             'aliases', 'is_obsolete', 'is_transport', 'ontology', 'pathways', 'notes', 'is_transport'] };
 
     // Compounds
@@ -279,7 +279,7 @@ function($s, Biochem, $state, $stateParams, MS, Session) {
         {label: 'Equation', key: 'stoichiometry', format: function(r) {
             if (!r.stoichiometry) return "N/A";
             var stoich = r.stoichiometry.replace(/\"/g, '')
-            return '<span style="white-space: wrap"'+'stoichiometry-to-eq="'+stoich+'" direction="'+r.direction+'"></span>';
+            return '<span style="white-space: wrap"'+'stoichiometry-to-eq="'+stoich+'" direction="'+r.reversibility+'"></span>';
         }},
         {label: 'Transport', key: 'is_transport', format: function(row){
             return row.is_transport? 'Yes' : 'No';
@@ -439,7 +439,7 @@ function($s, Biochem, $state, $stateParams, Session) {
     // cpd_Reactions
     var cpd_rxn_sFields = ['id', 'name', 'status', 'aliases', 'pathways', 'ontology', 'stoichiometry', 'notes'];
     $s.cpd_rxnOpts = {query: $s.id, limit: 25, offset: 0, sort: {field: 'id'}, core: 'reactions', searchFields: cpd_rxn_sFields,
-                  visible: ['name', 'id', 'definition', 'deltag', 'deltagerr', 'direction', 'stoichiometry', 'status',
+                  visible: ['name', 'id', 'definition', 'deltag', 'deltagerr','reversibility', 'stoichiometry', 'status',
                             'inchikey', 'smiles', 'aliases', 'is_obsolete', 'ontology', 'pathways', 'notes', 'is_transport'] };
 
     $s.cpd_rxnHeader = [
@@ -453,7 +453,7 @@ function($s, Biochem, $state, $stateParams, Session) {
         {label: 'Equation', key: 'stoichiometry', format: function(r) {
             if (!r.stoichiometry) return "N/A";
             var stoich = r.stoichiometry.replace(/\"/g, '')
-            return '<span style="white-space: wrap;"'+'stoichiometry-to-eq="'+stoich+'" direction="'+r.direction+'"></span>';
+            return '<span style="white-space: wrap;"'+'stoichiometry-to-eq="'+stoich+'" direction="'+r.reversibility+'"></span>';
         }},
         {label: 'Transport', key: 'is_transport', format: function(row){
             return row.is_transport? 'Yes' : 'No';

--- a/app/directives/directives.js
+++ b/app/directives/directives.js
@@ -2190,6 +2190,8 @@ function(Dialogs, $dialog) {
 
             if (dir === '=')
                 var dirClass = 'fa-arrows-h';
+            else if (dir == '?')
+                var dirClass = 'fa-arrows-h';
             else if (dir === '>')
                 var dirClass = 'fa-long-arrow-right';
             else if (dir === '<')
@@ -2243,7 +2245,12 @@ function(Dialogs, $dialog) {
             var parts = stoichString.split(';');
             var dir = scope.direction;
 
+            console.log("Testing")
+            console.log(dir)
+
             if (dir === '=')
+                var dirClass = 'fa-arrows-h';
+            else if (dir == '?')
                 var dirClass = 'fa-arrows-h';
             else if (dir === '>')
                 var dirClass = 'fa-long-arrow-right';

--- a/app/views/biochem/reaction.html
+++ b/app/views/biochem/reaction.html
@@ -61,7 +61,7 @@
 <div layout="row" ng-if="!loading">
     <div flex="20" layout="column"><strong>Equation</strong></div>
     <div flex="80" layout="column">
-        <span stoichiometry-to-imgs="{{rxn.stoichiometry}}" direction="{{rxn.direction}}"></span>
+        <span stoichiometry-to-imgs="{{rxn.stoichiometry}}" direction="{{rxn.reversibility}}"></span>
     </div>
 </div>
 <hr>
@@ -86,10 +86,6 @@
 <div layout="row">
     <div flex="20" layout="column"><strong>EC numbers</strong></div>
     <div flex="80" layout="column">{{rxn.ec_numbers_display}}</div>
-</div>
-<div layout="row">
-    <div flex="20" layout="column"><strong>Direction</strong></div>
-    <div flex="80" layout="column">{{rxn.direction}}</div>
 </div>
 <div layout="row">
     <div flex="20" layout="column"><strong>Thermodynamic reversibility</strong></div>


### PR DESCRIPTION
Removing direction had implications, and this is one of them. This bug fix restors the arrow of reaction direction in the web-pages