### PR TITLE
Fix biochem search reliability and harden DataControlHeader behavior

### DIFF
--- a/app/(reference-data)/biochem/compounds/[id]/page.tsx
+++ b/app/(reference-data)/biochem/compounds/[id]/page.tsx
@@ -307,6 +307,7 @@ const rxnColumns: GridColDef<Reaction>[] = [
 
 export default function CompoundDetailPage() {
     const { id } = useParams<{ id: string }>();
+    const [imageUnavailable, setImageUnavailable] = useState(false);
 
     // ── Compound data
     const { data: cpd, isLoading: loadingCpd, error } = useQuery({
@@ -385,13 +386,35 @@ export default function CompoundDetailPage() {
             <Box sx={{ display: 'flex', gap: 3, flexWrap: 'wrap', mb: 3 }}>
                 {/* Image */}
                 <Box sx={{ width: 220, flexShrink: 0 }}>
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                        src={getCompoundImageUrl(cpd.id)}
-                        alt={`Structure of ${cpd.id}`}
-                        style={{ maxWidth: '100%', height: 'auto', display: 'block' }}
-                        onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
-                    />
+                    {(!cpd.smiles || imageUnavailable) ? (
+                        <Box
+                            aria-label={`Compound image unavailable for ${cpd.id}`}
+                            sx={{
+                                width: '100%',
+                                minHeight: 220,
+                                border: '1px dashed #cbd5e1',
+                                borderRadius: 1,
+                                bgcolor: '#f8fafc',
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                textAlign: 'center',
+                                px: 2,
+                            }}
+                        >
+                            <Typography variant="body2" color="text.secondary">
+                                Compound image unavailable
+                            </Typography>
+                        </Box>
+                    ) : (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                            src={getCompoundImageUrl(cpd.id)}
+                            alt={`Structure of ${cpd.id}`}
+                            style={{ maxWidth: '100%', height: 'auto', display: 'block' }}
+                            onError={() => setImageUnavailable(true)}
+                        />
+                    )}
                 </Box>
 
                 {/* Properties */}

--- a/app/(reference-data)/biochem/compounds/page.tsx
+++ b/app/(reference-data)/biochem/compounds/page.tsx
@@ -134,6 +134,9 @@ const columns: GridColDef<Compound>[] = [
         field: 'ontology',
         headerName: 'Ontology',
         width: 200,
+        sortable: false,
+        /** Solr compounds_staging has no ontology field — server filters cannot target it */
+        filterable: false,
         valueGetter: (_value, row) => {
             if (!row.ontology || row.ontology === 'class:null|context:null') return 'N/A';
             return row.ontology;

--- a/app/(reference-data)/genomes/Annotations/page.tsx
+++ b/app/(reference-data)/genomes/Annotations/page.tsx
@@ -86,6 +86,22 @@ function FeatureLinks({ ids }: { ids: string[] }) {
     );
 }
 
+function ReactionLinks({ ids }: { ids: string[] }) {
+    if (!ids || ids.length === 0) return <>-</>;
+    return (
+        <span style={{ display: 'inline-block', maxWidth: 260 }}>
+            {ids.map((id, idx) => (
+                <span key={`${id}-${idx}`}>
+                    <Link href={`/biochem/reactions/${id}`} style={{ color: '#00acc1', textDecoration: 'none' }}>
+                        {id}
+                    </Link>
+                    {idx < ids.length - 1 && <br />}
+                </span>
+            ))}
+        </span>
+    );
+}
+
 export default function SubsystemsPage() {
     const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({ page: 0, pageSize: 25 });
     const [sortModel, setSortModel] = useState<GridSortModel>([{ field: 'role', sort: 'asc' }]);
@@ -154,7 +170,7 @@ export default function SubsystemsPage() {
                 field: 'reactions',
                 headerName: 'Reactions',
                 width: 200,
-                renderCell: (params) => <MultiLineList items={params.row.reactions} />,
+                renderCell: (params) => <ReactionLinks ids={params.row.reactions} />,
                 sortable: false,
             },
             {

--- a/app/(user-data)/my-jobs/page.tsx
+++ b/app/(user-data)/my-jobs/page.tsx
@@ -409,6 +409,7 @@ function MyJobsContent() {
                 showToolbar
                 slots={{ toolbar: DataControlHeader }}
                 slotProps={{ toolbar: { showQuickFilter: true } }}
+                hideFooter
                 disableRowSelectionOnClick
                 getRowId={(row) => row.id}
                 autoHeight

--- a/app/fba/[...path]/page.tsx
+++ b/app/fba/[...path]/page.tsx
@@ -820,6 +820,7 @@ export default function FbaPage({ params }: { params: Promise<{ path: string[] }
                             showToolbar
                             slots={{ toolbar: DataControlHeader }}
                             slotProps={{ toolbar: { showQuickFilter: true } }}
+                            hideFooter
                             disableRowSelectionOnClick
                             getRowId={(row) => row.id}
                             sx={{ border: '1px solid #e0e0e0', backgroundColor: '#fff', minHeight: 400 }}
@@ -838,6 +839,7 @@ export default function FbaPage({ params }: { params: Promise<{ path: string[] }
                             showToolbar
                             slots={{ toolbar: DataControlHeader }}
                             slotProps={{ toolbar: { showQuickFilter: true } }}
+                            hideFooter
                             disableRowSelectionOnClick
                             getRowId={(row) => row.id}
                             sx={{ border: '1px solid #e0e0e0', backgroundColor: '#fff', minHeight: 400 }}
@@ -879,6 +881,7 @@ export default function FbaPage({ params }: { params: Promise<{ path: string[] }
                                     showToolbar
                                     slots={{ toolbar: DataControlHeader }}
                                     slotProps={{ toolbar: { showQuickFilter: true } }}
+                                    hideFooter
                                     disableRowSelectionOnClick
                                     getRowId={(row) => row.id}
                                     sx={{ border: '1px solid #e0e0e0', backgroundColor: '#fff', minHeight: 400 }}

--- a/app/gapfill/[...path]/page.tsx
+++ b/app/gapfill/[...path]/page.tsx
@@ -371,6 +371,7 @@ export default function GapfillPage({ params }: { params: Promise<{ path: string
                     showToolbar
                     slots={{ toolbar: DataControlHeader }}
                     slotProps={{ toolbar: { showQuickFilter: true } }}
+                    hideFooter
                     disableRowSelectionOnClick
                     getRowId={(row) => row.id}
                     sx={{ border: '1px solid #e0e0e0', backgroundColor: '#fff', minHeight: 400 }}

--- a/app/genome/[...path]/page.tsx
+++ b/app/genome/[...path]/page.tsx
@@ -228,6 +228,7 @@ export default function GenomePage({ params }: { params: Promise<{ path: string[
                             showToolbar
                             slots={{ toolbar: DataControlHeader }}
                             slotProps={{ toolbar: { showQuickFilter: true } }}
+                            hideFooter
                             disableRowSelectionOnClick
                             getRowId={(row) => row.id}
                             sx={{ border: '1px solid #e0e0e0', backgroundColor: '#fff', minHeight: 400 }}
@@ -246,6 +247,7 @@ export default function GenomePage({ params }: { params: Promise<{ path: string[
                             showToolbar
                             slots={{ toolbar: DataControlHeader }}
                             slotProps={{ toolbar: { showQuickFilter: true } }}
+                            hideFooter
                             disableRowSelectionOnClick
                             getRowId={(row) => row.id}
                             sx={{ border: '1px solid #e0e0e0', backgroundColor: '#fff', minHeight: 400 }}

--- a/components/build-model/PatricGenomesTable.tsx
+++ b/components/build-model/PatricGenomesTable.tsx
@@ -61,10 +61,11 @@ export default function PatricGenomesTable({ onSelectGenome, disabled = false }:
             'patric-genomes',
             query,
             columnFiltersActive,
-            paginationModel.page,
-            paginationModel.pageSize,
+            // Only include pagination in query key for server mode (client-mode paginates in memory)
+            ...(columnFiltersActive ? [] : [paginationModel.page, paginationModel.pageSize]),
             sortToken,
-            filterModel.items,
+            // Stable string key for filter items (avoids new-reference re-fetches)
+            JSON.stringify(filterModel.items ?? []),
         ],
         queryFn: async () => {
             if (columnFiltersActive) {
@@ -75,9 +76,9 @@ export default function PatricGenomesTable({ onSelectGenome, disabled = false }:
                     sort: sortToken,
                 });
                 const filtered = filterDocsByGridModel(
-                    raw.rows as Record<string, unknown>[],
-                    (filterModel.items ?? []) as GridFilterItem[],
-                );
+                    raw.rows as unknown as Record<string, unknown>[],
+                    filterModel.items ?? [],
+                ) as unknown as PatricGenome[];
                 const sm = sortModel[0];
                 const sorted = sm?.field
                     ? sortGridDocsLocally(filtered, { field: sm.field, desc: sm.sort === 'desc' })

--- a/components/build-model/PatricGenomesTable.tsx
+++ b/components/build-model/PatricGenomesTable.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import {
     DataGrid,
     GridColDef,
+    type GridFilterItem,
     GridFilterModel,
     GridPaginationModel,
     GridSortModel,
@@ -13,7 +14,21 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import DataControlHeader from '@/components/layout/DataControlHeader';
+import { filterDocsByGridModel, sortGridDocsLocally } from '@/lib/api/biochem';
 import { PatricGenome, searchPatricGenomes } from '@/lib/api/patric';
+
+/** Max rows to pull when column filters need client-side evaluation (PATRIC RQL cannot express MUI operators). */
+const PATRIC_LOCAL_FILTER_BATCH = 5000;
+
+function hasActiveColumnFilters(items: GridFilterItem[] | undefined): boolean {
+    return (items ?? []).some((item) => {
+        if (!item.field || !item.operator) return false;
+        const op = String(item.operator);
+        if (op === 'isEmpty' || op === 'isNotEmpty') return true;
+        if (Array.isArray(item.value)) return item.value.length > 0;
+        return String(item.value ?? '').trim().length > 0;
+    });
+}
 
 interface PatricGenomesTableProps {
     onSelectGenome: (genome: PatricGenome) => void;
@@ -39,22 +54,46 @@ export default function PatricGenomesTable({ onSelectGenome, disabled = false }:
 
     const query = extractQuickFilterQuery(filterModel);
     const sortToken = toSortToken(sortModel);
+    const columnFiltersActive = hasActiveColumnFilters(filterModel.items as GridFilterItem[]);
 
     const { data, isLoading, error } = useQuery({
         queryKey: [
             'patric-genomes',
             query,
+            columnFiltersActive,
             paginationModel.page,
             paginationModel.pageSize,
             sortToken,
+            filterModel.items,
         ],
-        queryFn: () =>
-            searchPatricGenomes({
+        queryFn: async () => {
+            if (columnFiltersActive) {
+                const raw = await searchPatricGenomes({
+                    query,
+                    limit: PATRIC_LOCAL_FILTER_BATCH,
+                    offset: 0,
+                    sort: sortToken,
+                });
+                const filtered = filterDocsByGridModel(
+                    raw.rows as Record<string, unknown>[],
+                    (filterModel.items ?? []) as GridFilterItem[],
+                );
+                const sm = sortModel[0];
+                const sorted = sm?.field
+                    ? sortGridDocsLocally(filtered, { field: sm.field, desc: sm.sort === 'desc' })
+                    : filtered;
+                const total = sorted.length;
+                const start = paginationModel.page * paginationModel.pageSize;
+                const rows = sorted.slice(start, start + paginationModel.pageSize) as PatricGenome[];
+                return { rows, total };
+            }
+            return searchPatricGenomes({
                 query,
                 limit: paginationModel.pageSize,
                 offset: paginationModel.page * paginationModel.pageSize,
                 sort: sortToken,
-            }),
+            });
+        },
         staleTime: 30_000,
     });
 

--- a/components/layout/DataControlHeader.tsx
+++ b/components/layout/DataControlHeader.tsx
@@ -10,6 +10,7 @@ import {
     gridFilterModelSelector,
     type GridColDef,
     type GridFilterItem,
+    type GridFilterModel,
     GridLogicOperator,
 } from '@mui/x-data-grid';
 import Box from '@mui/material/Box';
@@ -344,7 +345,6 @@ type ToolbarFilterRow = {
     value: string;
 };
 
-
 function makeEmptyFilterRow(): ToolbarFilterRow {
     return {
         id: `filter-${Date.now()}-${Math.random().toString(16).slice(2)}`,
@@ -517,12 +517,14 @@ function ToolbarFilterEditor() {
                 value: toFilterValue(row),
             }));
 
-        apiRef.current.setFilterModel({
+        const newModel: GridFilterModel = {
             items,
             logicOperator: draftLogicOperator,
             quickFilterValues: filterModel?.quickFilterValues ?? [],
             quickFilterLogicOperator: filterModel?.quickFilterLogicOperator ?? GridLogicOperator.And,
-        });
+        };
+
+        apiRef.current.setFilterModel(newModel);
 
         allColumns.forEach((column) => {
             const visible = draftColumnVisibilityModel[column.field] !== false;

--- a/components/layout/DataControlHeader.tsx
+++ b/components/layout/DataControlHeader.tsx
@@ -360,8 +360,8 @@ function ToolbarFilterEditor() {
 
     const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
     const [allColumns, setAllColumns] = useState<GridColDef[]>([]);
-    // Community DataGrid supports only 1 filter item; we store exactly one draft row.
-    const [draftRow, setDraftRow] = useState<ToolbarFilterRow>(makeEmptyFilterRow());
+    const [draftRows, setDraftRows] = useState<ToolbarFilterRow[]>([]);
+    const [draftLogicOperator, setDraftLogicOperator] = useState<GridLogicOperator>(GridLogicOperator.And);
     const [draftColumnVisibilityModel, setDraftColumnVisibilityModel] = useState<Record<string, boolean>>({});
     const [appliedHiddenColumnCount, setAppliedHiddenColumnCount] = useState(0);
 
@@ -426,6 +426,20 @@ function ToolbarFilterEditor() {
         return raw;
     };
 
+    const addFilterRow = () => {
+        setDraftRows((prev) => [...prev, makeEmptyFilterRow()]);
+    };
+
+    const removeFilterRow = (id: string) => {
+        setDraftRows((prev) => prev.filter((row) => row.id !== id));
+    };
+
+    const updateFilterRow = (id: string, updates: Partial<ToolbarFilterRow>) => {
+        setDraftRows((prev) =>
+            prev.map((row) => (row.id === id ? { ...row, ...updates } : row)),
+        );
+    };
+
     const openEditor = (event: MouseEvent<HTMLButtonElement>) => {
         const columns = apiRef.current
             .getAllColumns()
@@ -444,27 +458,34 @@ function ToolbarFilterEditor() {
             Object.values(visibilityModel).filter((visible) => visible === false).length,
         );
 
-        // Load existing filter item (first only — Community DataGrid allows 1)
-        const existingItem = ((filterModel?.items ?? []) as GridFilterItem[])[0];
-        if (existingItem?.field) {
-            setDraftRow({
-                id: String(existingItem.id ?? `filter-${Math.random().toString(16).slice(2)}`),
-                field: String(existingItem.field ?? ''),
-                operator: String(existingItem.operator ?? ''),
-                value: Array.isArray(existingItem.value)
-                    ? existingItem.value.map(String).join(', ')
-                    : String(existingItem.value ?? ''),
-            });
+        // Load existing filter items
+        const existingItems = (filterModel?.items ?? []) as GridFilterItem[];
+        if (existingItems.length > 0 && existingItems[0]?.field) {
+            setDraftRows(
+                existingItems.map((item) => ({
+                    id: String(item.id ?? `filter-${Math.random().toString(16).slice(2)}`),
+                    field: String(item.field ?? ''),
+                    operator: String(item.operator ?? ''),
+                    value: Array.isArray(item.value)
+                        ? item.value.map(String).join(', ')
+                        : String(item.value ?? ''),
+                })),
+            );
         } else {
-            setDraftRow(makeEmptyFilterRow());
+            setDraftRows([makeEmptyFilterRow()]);
         }
+        setDraftLogicOperator(
+            filterModel?.logicOperator === GridLogicOperator.Or
+                ? GridLogicOperator.Or
+                : GridLogicOperator.And,
+        );
 
         setAnchorEl(event.currentTarget);
     };
 
     const closeEditor = () => setAnchorEl(null);
 
-    const clearFiltersDraft = () => setDraftRow(makeEmptyFilterRow());
+    const clearFiltersDraft = () => setDraftRows([makeEmptyFilterRow()]);
 
     const setAllColumnsVisibleDraft = (visible: boolean) => {
         setDraftColumnVisibilityModel((prev) => {
@@ -482,17 +503,23 @@ function ToolbarFilterEditor() {
             visible[column.field] = true;
         });
         setDraftColumnVisibilityModel(visible);
-        setDraftRow(makeEmptyFilterRow());
+        setDraftRows([makeEmptyFilterRow()]);
+        setDraftLogicOperator(GridLogicOperator.And);
     };
 
     const saveChanges = () => {
-        const items: GridFilterItem[] = isFilled(draftRow)
-            ? [{ id: draftRow.id, field: draftRow.field, operator: draftRow.operator, value: toFilterValue(draftRow) }]
-            : [];
+        const items: GridFilterItem[] = draftRows
+            .filter(isFilled)
+            .map((row) => ({
+                id: row.id,
+                field: row.field,
+                operator: row.operator,
+                value: toFilterValue(row),
+            }));
 
         apiRef.current.setFilterModel({
             items,
-            logicOperator: GridLogicOperator.And,
+            logicOperator: draftLogicOperator,
             quickFilterValues: filterModel?.quickFilterValues ?? [],
             quickFilterLogicOperator: filterModel?.quickFilterLogicOperator ?? GridLogicOperator.And,
         });
@@ -534,35 +561,51 @@ function ToolbarFilterEditor() {
                                 <Typography variant="subtitle2" fontWeight={600}>
                                     Column Filter
                                 </Typography>
-                                <Button variant="text" size="small" onClick={clearFiltersDraft}>
-                                    Clear
-                                </Button>
+                                <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+                                    <TextField
+                                        select
+                                        size="small"
+                                        label="Logic"
+                                        value={draftLogicOperator}
+                                        onChange={(e) =>
+                                            setDraftLogicOperator(e.target.value as GridLogicOperator)
+                                        }
+                                        sx={{ minWidth: 110 }}
+                                    >
+                                        <MenuItem value={GridLogicOperator.And}>AND</MenuItem>
+                                        <MenuItem value={GridLogicOperator.Or}>OR</MenuItem>
+                                    </TextField>
+                                    <Button variant="text" size="small" onClick={clearFiltersDraft}>
+                                        Clear All
+                                    </Button>
+                                </Box>
                             </Box>
-                            {(() => {
-                                const row = draftRow;
-                                const operators = operatorOptionsForField(row.field);
-                                const type = getColumnType(row.field);
-                                const noValueOp = isNoValueOperator(row.operator);
-                                const isArrayOp = ARRAY_VALUE_OPERATORS.has(row.operator);
-                                const isBoolean = type === 'boolean';
-                                const inputType =
-                                    type === 'number'
-                                        ? 'number'
-                                        : type === 'dateTime'
-                                            ? 'datetime-local'
-                                            : type === 'date'
-                                                ? 'date'
-                                                : 'text';
-                                const isDateInput = inputType === 'date' || inputType === 'datetime-local';
-                                const hint = isArrayOp ? ARRAY_OPERATOR_HINT[row.operator] : undefined;
+                            <Stack spacing={1.5}>
+                                {draftRows.map((row) => {
+                                    const operators = operatorOptionsForField(row.field);
+                                    const type = getColumnType(row.field);
+                                    const noValueOp = isNoValueOperator(row.operator);
+                                    const isArrayOp = ARRAY_VALUE_OPERATORS.has(row.operator);
+                                    const isBoolean = type === 'boolean';
+                                    const inputType =
+                                        type === 'number'
+                                            ? 'number'
+                                            : type === 'dateTime'
+                                                ? 'datetime-local'
+                                                : type === 'date'
+                                                    ? 'date'
+                                                    : 'text';
+                                    const isDateInput = inputType === 'date' || inputType === 'datetime-local';
+                                    const hint = isArrayOp ? ARRAY_OPERATOR_HINT[row.operator] : undefined;
 
-                                return (
-                                    <Stack spacing={1.5}>
+                                    return (
                                         <Box
+                                            key={row.id}
                                             sx={{
                                                 display: 'grid',
-                                                gridTemplateColumns: '1fr 1fr',
+                                                gridTemplateColumns: '1fr 1fr 1fr auto',
                                                 gap: 1,
+                                                alignItems: 'center',
                                             }}
                                         >
                                             <TextField
@@ -571,12 +614,11 @@ function ToolbarFilterEditor() {
                                                 label="Column"
                                                 value={row.field}
                                                 onChange={(e) =>
-                                                    setDraftRow((prev) => ({
-                                                        ...prev,
+                                                    updateFilterRow(row.id, {
                                                         field: e.target.value,
                                                         operator: '',
                                                         value: '',
-                                                    }))
+                                                    })
                                                 }
                                             >
                                                 <MenuItem value="">Select column</MenuItem>
@@ -594,11 +636,10 @@ function ToolbarFilterEditor() {
                                                 value={row.operator}
                                                 onChange={(e) => {
                                                     const next = e.target.value;
-                                                    setDraftRow((prev) => ({
-                                                        ...prev,
+                                                    updateFilterRow(row.id, {
                                                         operator: next,
-                                                        value: isNoValueOperator(next) ? '' : prev.value,
-                                                    }));
+                                                        value: isNoValueOperator(next) ? '' : row.value,
+                                                    });
                                                 }}
                                                 disabled={!row.field}
                                             >
@@ -609,37 +650,54 @@ function ToolbarFilterEditor() {
                                                     </MenuItem>
                                                 ))}
                                             </TextField>
-                                        </Box>
 
-                                        {isBoolean ? (
-                                            <TextField
-                                                select
+                                            {isBoolean ? (
+                                                <TextField
+                                                    select
+                                                    size="small"
+                                                    label="Value"
+                                                    value={row.value}
+                                                    onChange={(e) => updateFilterRow(row.id, { value: e.target.value })}
+                                                    disabled={!row.field || !row.operator || noValueOp}
+                                                >
+                                                    <MenuItem value="">Select</MenuItem>
+                                                    <MenuItem value="true">true</MenuItem>
+                                                    <MenuItem value="false">false</MenuItem>
+                                                </TextField>
+                                            ) : (
+                                                <TextField
+                                                    size="small"
+                                                    label="Value"
+                                                    value={row.value}
+                                                    onChange={(e) => updateFilterRow(row.id, { value: e.target.value })}
+                                                    disabled={!row.field || !row.operator || noValueOp}
+                                                    type={inputType}
+                                                    InputLabelProps={isDateInput ? { shrink: true } : undefined}
+                                                    helperText={hint}
+                                                    placeholder={isArrayOp ? 'value1, value2, ...' : undefined}
+                                                />
+                                            )}
+
+                                            <IconButton
                                                 size="small"
-                                                label="Value"
-                                                value={row.value}
-                                                onChange={(e) => setDraftRow((prev) => ({ ...prev, value: e.target.value }))}
-                                                disabled={!row.field || !row.operator || noValueOp}
+                                                onClick={() => removeFilterRow(row.id)}
+                                                disabled={draftRows.length <= 1}
+                                                aria-label="Remove filter"
                                             >
-                                                <MenuItem value="">Select</MenuItem>
-                                                <MenuItem value="true">true</MenuItem>
-                                                <MenuItem value="false">false</MenuItem>
-                                            </TextField>
-                                        ) : (
-                                            <TextField
-                                                size="small"
-                                                label="Value"
-                                                value={row.value}
-                                                onChange={(e) => setDraftRow((prev) => ({ ...prev, value: e.target.value }))}
-                                                disabled={!row.field || !row.operator || noValueOp}
-                                                type={inputType}
-                                                InputLabelProps={isDateInput ? { shrink: true } : undefined}
-                                                helperText={hint}
-                                                placeholder={isArrayOp ? 'value1, value2, ...' : undefined}
-                                            />
-                                        )}
-                                    </Stack>
-                                );
-                            })()}
+                                                <CloseIcon fontSize="small" />
+                                            </IconButton>
+                                        </Box>
+                                    );
+                                })}
+                            </Stack>
+                            <Button
+                                size="small"
+                                onClick={addFilterRow}
+                                sx={{ mt: 1 }}
+                                startIcon={<span style={{ fontSize: '1.2em', lineHeight: 1 }}>+</span>}
+                            >
+                                Add Filter
+                            </Button>
                         </Box>
 
                         <Box>

--- a/components/layout/DataControlHeader.tsx
+++ b/components/layout/DataControlHeader.tsx
@@ -7,6 +7,7 @@ import {
     gridPageSelector,
     gridPageSizeSelector,
     gridRowCountSelector,
+    gridFilteredRowCountSelector,
     gridFilterModelSelector,
     type GridColDef,
     type GridFilterItem,
@@ -87,11 +88,15 @@ function CustomPagination() {
     const apiRef = useGridApiContext();
     const page = useGridSelector(apiRef, gridPageSelector);
     const pageSize = useGridSelector(apiRef, gridPageSizeSelector);
+    // Use filtered row count so pagination shows correct total after client-side filtering
+    const filteredCount = useGridSelector(apiRef, gridFilteredRowCountSelector);
     const rowCount = useGridSelector(apiRef, gridRowCountSelector);
+    // Prefer filtered count (client-side filtering), fall back to total rowCount
+    const displayCount = filteredCount ?? rowCount;
+    const rowCountValue = displayCount ?? 0;
     const ready = page !== undefined && pageSize !== undefined && rowCount !== undefined;
     const pageValue = page ?? 0;
     const pageSizeValue = pageSize ?? 25;
-    const rowCountValue = rowCount ?? 0;
     const lastPage = Math.max(0, Math.ceil(rowCountValue / pageSizeValue) - 1);
     const safePage = Math.min(pageValue, lastPage);
 

--- a/components/layout/DataControlHeader.tsx
+++ b/components/layout/DataControlHeader.tsx
@@ -129,7 +129,11 @@ function CustomPagination() {
 function ToolbarSearchField() {
     const apiRef = useGridApiContext();
     const pathname = usePathname();
-    const [value, setValue] = useState('');
+    const gridFilterModel = useGridSelector(apiRef, gridFilterModelSelector);
+    const committedQuick = (gridFilterModel?.quickFilterValues ?? []).join(' ').trim();
+    /** When non-null, the user is editing; otherwise show the grid's committed quick filter. */
+    const [draftQuick, setDraftQuick] = useState<string | null>(null);
+    const displayValue = draftQuick ?? committedQuick;
     const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     const placeholder = useMemo(() => {
@@ -137,12 +141,15 @@ function ToolbarSearchField() {
         if (pathname.includes('/biochem/reactions')) return 'Find in reactions...';
         if (pathname.includes('/biochem/compounds')) return 'Find in compounds...';
         if (pathname.includes('/genomes/Annotations')) return 'Find in subsystems...';
-        if (pathname.includes('/reference-data/genomes')) return 'Find in plant models...';
-        if (pathname.includes('/reference-data/list-media')) return 'Find in media...';
+        if (pathname === '/genomes') return 'Find in plant models...';
+        if (pathname === '/list-media') return 'Find in media...';
         if (pathname.includes('/my-models')) return 'Find in my models...';
         if (pathname.includes('/my-jobs')) return 'Find in my jobs...';
         if (pathname.includes('/myMedia')) return 'Find in my media...';
         if (pathname.includes('/my-media')) return 'Find in my media...';
+        if (pathname.startsWith('/genome/')) return 'Find in genome...';
+        if (pathname.includes('/gapfill/')) return 'Find in gapfill reactions...';
+        if (pathname.includes('/fba/')) return 'Find in FBA results...';
         if (pathname.includes('/model/')) {
             if (pathname.endsWith('/reactions')) return 'Find in reactions...';
             if (pathname.endsWith('/compounds')) return 'Find in compounds...';
@@ -179,16 +186,21 @@ function ToolbarSearchField() {
     const handleChange = useCallback(
         (e: React.ChangeEvent<HTMLInputElement>) => {
             const term = e.target.value;
-            setValue(term);
+            setDraftQuick(term);
             if (debounceRef.current) clearTimeout(debounceRef.current);
-            debounceRef.current = setTimeout(() => applySearch(term), 300);
+            debounceRef.current = setTimeout(() => {
+                applySearch(term);
+                debounceRef.current = null;
+                setDraftQuick(null);
+            }, 300);
         },
         [applySearch],
     );
 
     const handleClear = useCallback(() => {
-        setValue('');
+        setDraftQuick(null);
         if (debounceRef.current) clearTimeout(debounceRef.current);
+        debounceRef.current = null;
         applySearch('');
     }, [applySearch]);
 
@@ -197,6 +209,7 @@ function ToolbarSearchField() {
         const api = apiRef.current;
         return () => {
             if (debounceRef.current) clearTimeout(debounceRef.current);
+            debounceRef.current = null;
             try {
                 const current = api.state.filter?.filterModel ?? { items: [] };
                 api.setFilterModel({
@@ -217,7 +230,7 @@ function ToolbarSearchField() {
 
     // Apply CSS Custom Highlight API to highlight matches in the grid
     useEffect(() => {
-        const term = value.trim();
+        const term = displayValue.trim();
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         if (!term || typeof CSS === 'undefined' || !('highlights' in (CSS as any))) {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -279,7 +292,7 @@ function ToolbarSearchField() {
                 ((CSS as any).highlights as any).delete('search-results');
             }
         };
-    }, [value, apiRef]);
+    }, [displayValue, apiRef]);
 
     return (
         <>
@@ -291,7 +304,7 @@ function ToolbarSearchField() {
                 }
             `}} />
             <TextField
-                value={value}
+                value={displayValue}
                 onChange={handleChange}
                 onKeyDown={(e) => {
                     if (e.key === 'Escape') handleClear();
@@ -305,7 +318,7 @@ function ToolbarSearchField() {
                             <SearchIcon fontSize="small" sx={{ color: 'text.secondary' }} />
                         </InputAdornment>
                     ),
-                    endAdornment: value ? (
+                    endAdornment: displayValue ? (
                         <InputAdornment position="end">
                             <IconButton
                                 size="small"

--- a/components/ui/MoleculeRenderer.tsx
+++ b/components/ui/MoleculeRenderer.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import Image from 'next/image';
 import Skeleton from '@mui/material/Skeleton';
+import Typography from '@mui/material/Typography';
 import { getRDKit } from '@/lib/rdkit';
 import { getCompoundImageUrl } from '@/lib/api/biochem';
 
@@ -42,7 +43,8 @@ export default function MoleculeRenderer({
         let cancelled = false;
 
         if (!smiles) {
-            setState('png');
+            // No structural string from API; avoid rendering empty/transparent fallback images.
+            setState('hidden');
             return;
         }
 
@@ -153,5 +155,28 @@ export default function MoleculeRenderer({
     }
 
     // state === 'hidden': no structure available at all
-    return null;
+    return (
+        <div
+            aria-label={`Compound image unavailable for ${compoundId}`}
+            style={{
+                width,
+                height,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                border: '1px dashed #cbd5e1',
+                borderRadius: 4,
+                background: '#f8fafc',
+                padding: 8,
+                boxSizing: 'border-box',
+            }}
+        >
+            <Typography
+                variant="caption"
+                sx={{ color: 'text.secondary', textAlign: 'center', lineHeight: 1.3 }}
+            >
+                Compound image unavailable
+            </Typography>
+        </div>
+    );
 }

--- a/components/ui/ReactionKnockoutsDialog.tsx
+++ b/components/ui/ReactionKnockoutsDialog.tsx
@@ -165,6 +165,7 @@ export default function ReactionKnockoutsDialog({
                     showToolbar
                     slots={{ toolbar: DataControlHeader }}
                     slotProps={{ toolbar: { showQuickFilter: true } }}
+                    hideFooter
                     autoHeight
                     disableRowSelectionOnClick={false}
                     sx={{

--- a/docs/DATA_CONTROL_HEADER.md
+++ b/docs/DATA_CONTROL_HEADER.md
@@ -1,0 +1,44 @@
+# DataControlHeader integration map
+
+This document lists every place the shared toolbar (`components/layout/DataControlHeader.tsx`) is mounted and how each grid applies search, column filters, sorting, and pagination.
+
+## Toolbar capabilities
+
+- **Quick search** — writes `filterModel.quickFilterValues` (debounced). Highlighting uses the CSS Custom Highlight API where supported; `GridHighlightText` also reads quick-filter terms.
+- **Filter and columns** — single column filter row (Community DataGrid limit) plus visibility toggles. Operators depend on column `type` (string, number, boolean, date).
+- **Pagination** — toolbar `TablePagination` is the primary control; grids that use this toolbar should set **`hideFooter`** so the default DataGrid footer does not duplicate pagination.
+
+## Page-by-page behavior
+
+| Location | Data source | Grid modes | Notes |
+|----------|-------------|------------|--------|
+| `app/(reference-data)/biochem/reactions/page.tsx` | Solr | `paginationMode`, `sortingMode`, `filterMode`: **server** | Quick search and column filters are translated in `lib/api/biochem.ts` (`buildSolrUrl`). |
+| `app/(reference-data)/biochem/compounds/page.tsx` | Solr | server | Same as reactions. Compound Solr schema has no `ontology` query field; ontology column is not server-filterable. |
+| `app/(reference-data)/list-media/page.tsx` | modelseed-api or workspace | **client** (all rows loaded) | Quick search and filters run on loaded rows. |
+| `app/(reference-data)/genomes/page.tsx` | API / static list | **client** | Same pattern. |
+| `app/(reference-data)/genomes/Annotations/page.tsx` | Client data | **client** | Same pattern. |
+| `app/(user-data)/my-models/page.tsx` | modelseed-api / workspace | **client** | `hideFooter` set. |
+| `app/(user-data)/myMedia/page.tsx` | workspace | **client** | `hideFooter` set. |
+| `app/(user-data)/my-jobs/page.tsx` | Client job list | **client** | `hideFooter` set. |
+| `app/model/[...path]/page.tsx` | Model sub-tabs | **client** or **server** (lazy tabs) | Per-tab configuration; uses `hideFooter` where the toolbar controls paging. |
+| `app/genome/[...path]/page.tsx` | Loaded genome object | **client** | `hideFooter` on both grids. |
+| `app/gapfill/[...path]/page.tsx` | Loaded gapfill solution | **client** | `hideFooter`. |
+| `app/fba/[...path]/page.tsx` | FBA results | **client** | `hideFooter` on reaction, exchange, and pathway map grids. |
+| `components/build-model/PatricGenomesTable.tsx` | PATRIC / BV-BRC API | **server** when only quick search; **client batch** when column filters active | Quick search maps to RQL. Column filters are not expressible in RQL; when a column filter is active, the table fetches up to 5000 rows, then applies `filterDocsByGridModel` / `sortGridDocsLocally` from `lib/api/biochem.ts` and paginates in memory. |
+| `components/build-model/RastGenomesTable.tsx` | modelseed-api list | **client** | All rows loaded; full toolbar semantics on in-memory data. |
+| `components/ui/ReactionKnockoutsDialog.tsx` | In-memory reactions | **client** | `hideFooter`. |
+
+## REST biochem helpers (not used by public biochem routes)
+
+`getReactionsFromModelseedApi` / `getCompoundsFromModelseedApi` apply quick search, optional local refinement, column filters, sort, and slice in `fetchModelseedApiBiochem`. See code comments for fetch caps and `numFound` semantics.
+
+## Verification
+
+- Biochem Solr: `tests/e2e/datacontrol-header.spec.ts`, `tests/e2e/biochem/*.spec.ts`, `tests/unit/api/biochem.test.ts`.
+- REST biochem batch path: `tests/unit/api/biochem-rest-filtering.test.ts`.
+- Local filter helper: `filterDocsByGridModel` test in `tests/unit/api/biochem.test.ts`.
+
+## Timestamp Log
+
+- Created: 2026-05-04 12:15:00 UTC — Initial inventory and behavior notes.
+- Updated: 2026-05-04 12:20:00 UTC — Documented PATRIC local filter batch, toolbar search sync pattern, and E2E additions.

--- a/lib/api/biochem.ts
+++ b/lib/api/biochem.ts
@@ -290,7 +290,13 @@ function buildSolrUrl(collection: string, opts: SolrQueryOpts = {}): string {
         url += `&fl=${visible.join(',')}`;
     }
 
-    const filterClauses = (filterModel?.items ?? [])
+    // Filter out ontology field for compounds (Solr compounds_staging has no ontology field)
+    const filterItems = (filterModel?.items ?? []).filter(item => {
+        const field = toSolrField(String(item.field ?? ''));
+        return !(collection === 'compounds' && field === 'ontology');
+    });
+
+    const filterClauses = filterItems
         .map((item) => buildFilterClause(item))
         .filter((clause): clause is string => Boolean(clause));
     const filterLogic = filterModel?.logicOperator === 'or' ? ' OR ' : ' AND ';
@@ -588,6 +594,25 @@ function matchesFilterItem(
                 return fieldNum === valueNum;
             case '!=':
                 return fieldNum !== valueNum;
+        }
+    }
+
+    // Handle date operators for non-numeric fields (e.g., date strings)
+    const dateOperators = ['after', 'before', 'onOrAfter', 'onOrBefore'];
+    if (dateOperators.includes(operator)) {
+        const fieldDate = new Date(fieldValue);
+        const valueDate = new Date(value);
+        if (!Number.isNaN(fieldDate.getTime()) && !Number.isNaN(valueDate.getTime())) {
+            switch (operator) {
+                case 'after':
+                    return fieldDate > valueDate;
+                case 'before':
+                    return fieldDate < valueDate;
+                case 'onOrAfter':
+                    return fieldDate >= valueDate;
+                case 'onOrBefore':
+                    return fieldDate <= valueDate;
+            }
         }
     }
 

--- a/lib/api/biochem.ts
+++ b/lib/api/biochem.ts
@@ -83,6 +83,7 @@ export interface SolrQueryOpts {
     limit?: number;
     offset?: number;
     sort?: { field: string; desc?: boolean };
+    /** Solr field list for quick search OR for modelseed-api local quick-refine (see get*FromModelseedApi). */
     searchFields?: string[];
     queryColumn?: Record<string, string>;
     visible?: string[];
@@ -368,11 +369,78 @@ async function fetchSolr<T>(url: string): Promise<SolrResponse<T>> {
  * Note: reaction/compound pages are pinned to legacy Solr; this is for
  * other consumers that intentionally target modelseed-api.
  */
+/**
+ * Resolved JSON field used for sorting (UI column `synonyms` → Solr/REST `aliases`).
+ */
+function resolveDocFieldKey(field: string): string {
+    return toSolrField(field);
+}
+
+/** Terms taken from toolbar quick search when no explicit Solr `query` is set. */
+function quickTermsFromOpts(
+    explicitQuery: string | undefined,
+    filterModel?: GridFilterModel,
+): string[] {
+    if (explicitQuery != null && String(explicitQuery).trim().length > 0) {
+        return [normalizeFilterValue(explicitQuery)];
+    }
+    return (filterModel?.quickFilterValues ?? [])
+        .map((v) => normalizeFilterValue(v))
+        .filter(Boolean);
+}
+
+/**
+ * Approximate Solr quick-search behavior on the REST payload: AND/OR of terms where
+ * each term matches if ANY search field matches (substring, case-insensitive).
+ * Short tokens mirror Solr prefix behavior (MIN_WILDCARD_QUERY_LENGTH).
+ */
+function docsPassRestQuickSearch(
+    docs: Record<string, unknown>[],
+    terms: string[],
+    searchFields: string[],
+    logicOperator: 'and' | 'or',
+): Record<string, unknown>[] {
+    if (terms.length === 0 || searchFields.length === 0) return docs;
+
+    return docs.filter((doc) =>
+        docsPassRestQuickSearchRow(doc, terms, searchFields, logicOperator));
+}
+
+function docsPassRestQuickSearchRow(
+    doc: Record<string, unknown>,
+    terms: string[],
+    searchFields: string[],
+    logicOperator: 'and' | 'or',
+): boolean {
+    const joiner = logicOperator === 'or' ? 'some' : 'every';
+    return terms[joiner]((rawTerm) => {
+        const term = normalizeFilterValue(rawTerm);
+        const tnorm = term.toLowerCase();
+        const usePrefixOnly = toSolrWildcardToken(term).length < MIN_WILDCARD_QUERY_LENGTH;
+        return searchFields.some((sf) => {
+            const fv = normalizeFieldValue(doc[resolveDocFieldKey(sf)]).toLowerCase();
+            return usePrefixOnly ? fv.startsWith(tnorm) : fv.includes(tnorm);
+        });
+    });
+}
+
 async function fetchModelseedApiBiochem<T>(
     endpoint: string,
     opts: SolrQueryOpts = {}
 ): Promise<SolrResponse<T>> {
-    const { query, limit = 25, offset = 0, filterModel, sort } = opts;
+    const {
+        query,
+        limit = 25,
+        offset = 0,
+        filterModel,
+        sort,
+        searchFields:
+            incomingSearchFields,
+    } = opts;
+
+    const searchFields = (incomingSearchFields && incomingSearchFields.length > 0)
+        ? incomingSearchFields
+        : (endpoint === 'compounds' ? CPD_SEARCH_FIELDS : RXN_SEARCH_FIELDS);
 
     let activeSearch = query;
     if (!activeSearch && filterModel?.quickFilterValues && filterModel.quickFilterValues.length > 0) {
@@ -383,12 +451,27 @@ async function fetchModelseedApiBiochem<T>(
     }
 
     const hasColumnFilters = (filterModel?.items?.length ?? 0) > 0;
-    const needsLocalTransforms = hasColumnFilters || Boolean(sort);
-    // Guardrail to avoid excessive payload sizes when offset is large.
-    const MAX_REST_FETCH_LIMIT = 5000;
-    const fetchLimit = needsLocalTransforms
-        ? Math.min(Math.max(limit + offset, 1000), MAX_REST_FETCH_LIMIT)
-        : Math.min(limit, MAX_REST_FETCH_LIMIT);
+    const quickTerms = quickTermsFromOpts(query, filterModel);
+    /** REST endpoints do not pass Solr `start`/`offset`; we must fetch enough rows to slice. */
+    const minRowsForPaging = Math.max(limit + offset, 1);
+
+    /*
+     * modelseed-api list/search does not pass Solr offsets: we slice client-side after fetch.
+     * When quick search narrows logically across multiple columns (Solr-style OR), widen the REST
+     * pull then refine locally. Column filters/sort also operate on client batches.
+     */
+    const MAX_CAP = 5000;
+    const quickRefine = quickTerms.length > 0;
+    const wantsWideHeap = Boolean(sort) || hasColumnFilters || quickRefine;
+
+    let fetchLimit: number;
+    if (!wantsWideHeap) {
+        fetchLimit = Math.min(MAX_CAP, minRowsForPaging);
+    } else if (quickRefine) {
+        fetchLimit = MAX_CAP;
+    } else {
+        fetchLimit = Math.min(MAX_CAP, Math.max(minRowsForPaging, 1000));
+    }
 
     const primaryUrl = activeSearch
         ? `${MODELSEED_API_URL}/api/biochem/search?query=${encodeURIComponent(activeSearch)}&limit=${fetchLimit}&type=${endpoint}`
@@ -406,16 +489,25 @@ async function fetchModelseedApiBiochem<T>(
         ? (data as T[])
         : ((data.docs || []) as T[]);
 
+    let working = rawDocs as unknown as Record<string, unknown>[];
+    working = docsPassRestQuickSearch(
+        working,
+        quickTerms,
+        searchFields,
+        filterModel?.quickFilterLogicOperator === 'or' ? 'or' : 'and',
+    );
+
     const filteredDocs = hasColumnFilters
-        ? rawDocs.filter((doc) => matchesFilterModel(doc as Record<string, unknown>, filterModel?.items ?? []))
-        : rawDocs;
-    const sortedDocs = sort ? sortDocs(filteredDocs, sort) : filteredDocs;
+        ? working.filter((doc) =>
+            matchesFilterModel(doc as Record<string, unknown>, filterModel?.items ?? [], endpoint))
+        : working;
+    const sortedDocs = sort ? sortDocs(filteredDocs, sort, resolveDocFieldKey) : filteredDocs;
     const pagedDocs = sortedDocs.slice(offset, offset + limit);
 
     return {
         numFound: sortedDocs.length,
         start: offset,
-        docs: pagedDocs,
+        docs: pagedDocs as unknown as T[],
     };
 }
 
@@ -448,10 +540,17 @@ function compareStringByOperator(fieldValue: string, operator: string, filterVal
     }
 }
 
-function matchesFilterItem(doc: Record<string, unknown>, item: GridFilterItem): boolean {
+function matchesFilterItem(
+    doc: Record<string, unknown>,
+    item: GridFilterItem,
+    endpoint?: string,
+): boolean {
     const operator = String(item.operator ?? '');
     const field = toSolrField(String(item.field ?? ''));
     if (!field || !operator) return true;
+
+    /* Solr compounds_staging has no ontology query field — REST payloads typically omit it too. */
+    if (endpoint === 'compounds' && field === 'ontology') return true;
 
     const rawField = doc[field];
     const fieldValue = normalizeFieldValue(rawField);
@@ -494,18 +593,27 @@ function matchesFilterItem(doc: Record<string, unknown>, item: GridFilterItem): 
     return compareStringByOperator(fieldValue, operator, value);
 }
 
-function matchesFilterModel(doc: Record<string, unknown>, items: GridFilterItem[]): boolean {
+function matchesFilterModel(
+    doc: Record<string, unknown>,
+    items: GridFilterItem[],
+    endpoint?: string,
+): boolean {
     const activeItems = items.filter((item) => item.field && item.operator);
     if (activeItems.length === 0) return true;
-    return activeItems.every((item) => matchesFilterItem(doc, item));
+    return activeItems.every((item) => matchesFilterItem(doc, item, endpoint));
 }
 
-function sortDocs<T>(docs: T[], sort: { field: string; desc?: boolean }): T[] {
+function sortDocs<T>(
+    docs: T[],
+    sort: { field: string; desc?: boolean },
+    resolveSortKey?: (field: string) => string,
+): T[] {
     const { field, desc } = sort;
     const direction = desc ? -1 : 1;
+    const key = resolveSortKey ? resolveSortKey(field) : field;
     return [...docs].sort((a, b) => {
-        const av = (a as Record<string, unknown>)[field];
-        const bv = (b as Record<string, unknown>)[field];
+        const av = (a as Record<string, unknown>)[key];
+        const bv = (b as Record<string, unknown>)[key];
         const aNum = Number(av);
         const bNum = Number(bv);
         if (Number.isFinite(aNum) && Number.isFinite(bNum)) {
@@ -636,7 +744,13 @@ export async function getCompounds(opts: SolrQueryOpts = {}): Promise<SolrRespon
 export async function getReactionsFromModelseedApi(
     opts: SolrQueryOpts = {}
 ): Promise<SolrResponse<Reaction>> {
-    const res = await fetchModelseedApiBiochem<Reaction>('reactions', opts);
+    const res = await fetchModelseedApiBiochem<Reaction>('reactions', {
+        limit: 25,
+        offset: 0,
+        sort: { field: 'id' },
+        searchFields: RXN_SEARCH_FIELDS,
+        ...opts,
+    });
     res.docs.forEach((doc) => {
         if (doc.is_obsolete === '1') {
             doc.status += ' (and is obsolete)';
@@ -652,7 +766,13 @@ export async function getReactionsFromModelseedApi(
 export async function getCompoundsFromModelseedApi(
     opts: SolrQueryOpts = {}
 ): Promise<SolrResponse<Compound>> {
-    return fetchModelseedApiBiochem<Compound>('compounds', opts);
+    return fetchModelseedApiBiochem<Compound>('compounds', {
+        limit: 25,
+        offset: 0,
+        sort: { field: 'id' },
+        searchFields: CPD_SEARCH_FIELDS,
+        ...opts,
+    });
 }
 
 /**

--- a/lib/api/biochem.ts
+++ b/lib/api/biochem.ts
@@ -514,6 +514,7 @@ async function fetchModelseedApiBiochem<T>(
 function normalizeFieldValue(value: unknown): string {
     if (Array.isArray(value)) return value.map((v) => String(v ?? '')).join(' ');
     if (value == null) return '';
+    if (value instanceof Date) return value.toISOString();
     return String(value);
 }
 
@@ -621,6 +622,28 @@ function sortDocs<T>(
         }
         return direction * normalizeFieldValue(av).localeCompare(normalizeFieldValue(bv));
     });
+}
+
+/**
+ * Apply MUI column filter items to row objects locally (for APIs that cannot express filters server-side).
+ * Uses the same operator semantics as Solr-backed biochem when used with `get*FromModelseedApi`.
+ */
+export function filterDocsByGridModel<T extends Record<string, unknown>>(
+    docs: T[],
+    items: GridFilterItem[],
+    endpoint?: string,
+): T[] {
+    if (!items.length) return docs;
+    return docs.filter((doc) => matchesFilterModel(doc, items, endpoint));
+}
+
+/** Client-side sort helper for grids that batch-fetch then paginate (e.g. PATRIC with column filters). */
+export function sortGridDocsLocally<T>(
+    docs: T[],
+    sort: { field: string; desc?: boolean },
+    resolveField?: (field: string) => string,
+): T[] {
+    return sortDocs(docs, sort, resolveField);
 }
 
 /* ─── Constants ──────────────────────────────────────────────── */

--- a/lib/api/biochem.ts
+++ b/lib/api/biochem.ts
@@ -348,7 +348,17 @@ function buildSolrUrl(collection: string, opts: SolrQueryOpts = {}): string {
 
 async function fetchSolr<T>(url: string): Promise<SolrResponse<T>> {
     const res = await fetch(url);
-    if (!res.ok) throw new Error(`Solr request failed: ${res.status}`);
+    if (!res.ok) {
+        let detail = '';
+        try {
+            const text = await res.text();
+            const parsed = JSON.parse(text) as { error?: { msg?: string } };
+            detail = parsed?.error?.msg ? `: ${parsed.error.msg}` : (text?.slice(0, 240) ?? '');
+        } catch {
+            // ignore JSON parse failures
+        }
+        throw new Error(`Solr request failed: ${res.status}${detail}`);
+    }
     const json = await res.json();
     return json.response as SolrResponse<T>;
 }
@@ -523,13 +533,17 @@ const RXN_VISIBLE = [
     'is_transport', 'ontology', 'pathways', 'notes',
 ];
 
-/** Compound search fields matching legacy `cpd_sFields`. */
-const CPD_SEARCH_FIELDS = ['id', 'name', 'formula', 'synonyms', 'aliases', 'ontology'];
+/**
+ * Compound quick-search fields — must exist on Solr `compounds_staging`.
+ * Note: Solr does not expose an `ontology` field on compounds; querying it yields 400
+ * ("undefined field ontology") and breaks the whole quick-search clause.
+ */
+const CPD_SEARCH_FIELDS = ['id', 'name', 'formula', 'synonyms', 'aliases'];
 
-/** Compound visible fields matching legacy `cpdOpts.visible`. */
+/** Compound visible fields matching Solr `compounds_staging` stored fields (see fl=). */
 const CPD_VISIBLE = [
     'name', 'id', 'formula', 'mass', 'abbreviation', 'deltag', 'deltagerr',
-    'charge', 'aliases', 'ontology',
+    'charge', 'aliases',
 ];
 
 /* ─── Public API ─────────────────────────────────────────────── */

--- a/lib/api/biochem.ts
+++ b/lib/api/biochem.ts
@@ -160,6 +160,69 @@ function toRangeBoundary(value: string): string {
     return `"${escapeSolrPhrase(value)}"`;
 }
 
+/** True when the value has ASCII letters and may need case-variant matching. */
+function hasAsciiLetters(value: string): boolean {
+    return /[A-Za-z]/.test(value);
+}
+
+/** Title-case words for mixed-case fallback variants. */
+function toTitleCaseWords(value: string): string {
+    return value.replace(/[A-Za-z]+/g, (word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase());
+}
+
+/** Build case variants for legacy Solr fields that are case-sensitive. */
+function buildCaseVariants(value: string): string[] {
+    const trimmed = value.trim();
+    if (!trimmed) return [];
+    if (!hasAsciiLetters(trimmed)) return [trimmed];
+
+    return Array.from(
+        new Set([
+            trimmed,
+            trimmed.toLowerCase(),
+            trimmed.toUpperCase(),
+            toTitleCaseWords(trimmed),
+        ]),
+    );
+}
+
+function joinOrClauses(clauses: string[]): string | null {
+    if (clauses.length === 0) return null;
+    if (clauses.length === 1) return clauses[0];
+    return `(${clauses.join(' OR ')})`;
+}
+
+function buildEqualsVariantClause(field: string, value: string): string | null {
+    const clauses = Array.from(
+        new Set(buildCaseVariants(value).map((entry) => `${field}:${toSolrLiteral(entry)}`)),
+    );
+    return joinOrClauses(clauses);
+}
+
+function buildWildcardVariantClause(
+    field: string,
+    value: string,
+    mode: 'contains' | 'startsWith' | 'endsWith',
+): string | null {
+    const clauses = buildCaseVariants(value)
+        .map((entry) => {
+            const token = toSolrWildcardToken(entry);
+            if (!token) return '';
+            switch (mode) {
+                case 'startsWith':
+                    return `${field}:${token}*`;
+                case 'endsWith':
+                    return `${field}:*${token}`;
+                case 'contains':
+                default:
+                    return `${field}:*${token}*`;
+            }
+        })
+        .filter((clause): clause is string => Boolean(clause));
+
+    return joinOrClauses(Array.from(new Set(clauses)));
+}
+
 /** Build a single Solr clause from one DataGrid filter item. */
 function buildFilterClause(item: GridFilterItem): string | null {
     const field = toSolrField(item.field);
@@ -175,8 +238,6 @@ function buildFilterClause(item: GridFilterItem): string | null {
     }
 
     const value = normalizeFilterValue(rawValue);
-    const wildcardValue = toSolrWildcardToken(value);
-    const literalValue = toSolrLiteral(value);
     const rangeBoundary = toRangeBoundary(value);
 
     switch (operator) {
@@ -199,17 +260,23 @@ function buildFilterClause(item: GridFilterItem): string | null {
         case '=':
         case 'equals':
         case 'is':
-            return `${field}:${literalValue}`;
+            return buildEqualsVariantClause(field, value);
         case '!=':
         case 'not':
         case 'doesNotEqual':
-            return `-${field}:${literalValue}`;
+            return (() => {
+                const equalsClause = buildEqualsVariantClause(field, value);
+                return equalsClause ? `-${equalsClause}` : null;
+            })();
         case 'startsWith':
-            return wildcardValue ? `${field}:${wildcardValue}*` : null;
+            return buildWildcardVariantClause(field, value, 'startsWith');
         case 'endsWith':
-            return wildcardValue ? `${field}:*${wildcardValue}` : null;
+            return buildWildcardVariantClause(field, value, 'endsWith');
         case 'doesNotContain':
-            return wildcardValue ? `-${field}:*${wildcardValue}*` : null;
+            return (() => {
+                const containsClause = buildWildcardVariantClause(field, value, 'contains');
+                return containsClause ? `-${containsClause}` : null;
+            })();
         case 'isAnyOf': {
             const values = Array.isArray(rawValue)
                 ? rawValue.map((entry) => normalizeFilterValue(entry)).filter(Boolean)
@@ -218,11 +285,14 @@ function buildFilterClause(item: GridFilterItem): string | null {
                     .map((entry) => entry.trim())
                     .filter(Boolean);
             if (values.length === 0) return null;
-            return `(${values.map((entry) => `${field}:${toSolrLiteral(entry)}`).join(' OR ')})`;
+            const valueClauses = values
+                .map((entry) => buildEqualsVariantClause(field, entry))
+                .filter((clause): clause is string => Boolean(clause));
+            return joinOrClauses(valueClauses);
         }
         case 'contains':
         default:
-            return wildcardValue ? `${field}:*${wildcardValue}*` : null;
+            return buildWildcardVariantClause(field, value, 'contains');
     }
 }
 

--- a/tests/e2e/biochem/compounds.spec.ts
+++ b/tests/e2e/biochem/compounds.spec.ts
@@ -16,6 +16,24 @@ test.describe('Compounds Page - Search & Display', () => {
         expect(count).toBeGreaterThan(0);
     });
 
+    test('should resolve a specific compound ID (cpd05323)', async ({ page }) => {
+        const searchInput = page.locator('input[placeholder*="Find in"]').first();
+        await searchInput.fill('cpd05323');
+        await expect(page.locator('a[href="/biochem/compounds/cpd05323"]').first()).toBeVisible({
+            timeout: 20000,
+        });
+    });
+
+    test('should match compound name case-insensitively (glucoiberin → Glucoiberin)', async ({
+        page,
+    }) => {
+        const searchInput = page.locator('input[placeholder*="Find in"]').first();
+        await searchInput.fill('glucoiberin');
+        await expect(page.locator('a[href="/biochem/compounds/cpd05323"]').first()).toBeVisible({
+            timeout: 20000,
+        });
+    });
+
     test('should open export modal with column selection', async ({ page }) => {
         const exportButton = page.locator('button:has-text("Export CSV")');
         await expect(exportButton).toBeVisible();

--- a/tests/e2e/datacontrol-header.spec.ts
+++ b/tests/e2e/datacontrol-header.spec.ts
@@ -145,4 +145,23 @@ test.describe('DataControlHeader - cross-page smoke', () => {
     await searchWithHeader(page, 'plant');
     await expect(page.locator('input[placeholder*="Find in"]').first()).toHaveValue('plant');
   });
+
+  test('genomes Annotations page shows subsystem search placeholder and filter dialog', async ({
+    page,
+  }) => {
+    await page.goto('/genomes/Annotations');
+    await waitForGridData(page, false);
+    await expect(page.locator('input[placeholder*="Find in subsystems"]')).toBeVisible({
+      timeout: 15000,
+    });
+    await openFilterDialog(page);
+    await page.locator('button:has-text("Cancel")').first().click();
+  });
+
+  test('my-jobs grid uses toolbar pagination only (no duplicate footer)', async ({ page }) => {
+    await page.goto('/my-jobs');
+    await waitForGridData(page, false);
+    const footers = page.locator('.MuiTablePagination-root');
+    await expect(footers).toHaveCount(1);
+  });
 });

--- a/tests/unit/api/biochem-rest-filtering.test.ts
+++ b/tests/unit/api/biochem-rest-filtering.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('biochem REST path local filter/sort/pagination', () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
     vi.resetModules();
     process.env.NEXT_PUBLIC_MODELSEED_API_URL = 'http://localhost:8000';
   });
@@ -55,5 +56,85 @@ describe('biochem REST path local filter/sort/pagination', () => {
     expect(res.start).toBe(1);
     expect(res.docs).toHaveLength(1);
     expect(res.docs[0]?.id).toBe('rxn00002');
+  });
+
+  it('requests widened biochem batches when refining quick-search client-side', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        { id: 'cpd05323', name: 'Glucoiberin', formula: '', aliases: [] },
+        { id: 'cpd09999', name: 'noise', formula: '', aliases: [] },
+      ],
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const biochem = await import('@/lib/api/biochem');
+    await biochem.getCompoundsFromModelseedApi({
+      limit: 25,
+      offset: 0,
+      filterModel: {
+        items: [],
+        logicOperator: 'and',
+        quickFilterValues: ['glucoiberin'],
+        quickFilterLogicOperator: 'and',
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(String(fetchMock.mock.calls[0]?.[0] ?? '')).toContain('limit=5000');
+
+    fetchMock.mockClear();
+    await biochem.getCompoundsFromModelseedApi({
+      limit: 25,
+      offset: 25,
+      sort: undefined,
+      filterModel: {
+        items: [],
+        logicOperator: 'and',
+        quickFilterValues: ['cpd'],
+        quickFilterLogicOperator: 'and',
+      },
+    });
+    expect(String(fetchMock.mock.calls[0]?.[0] ?? '')).toContain('limit=5000');
+  });
+
+  it('ignores ontology column filters on compound REST payloads (Solr has no ontology field)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [{ id: 'cpd00001', name: 'ATP', formula: '', aliases: [] }],
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const biochem = await import('@/lib/api/biochem');
+    const res = await biochem.getCompoundsFromModelseedApi({
+      limit: 10,
+      filterModel: {
+        items: [{ field: 'ontology', operator: 'contains', value: 'nope-miss' }],
+        quickFilterValues: [],
+      },
+    });
+    expect(res.docs).toHaveLength(1);
+  });
+
+  it('refines quick search across compound fields locally (OR across searchFields)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        { id: 'cpd11111', name: 'zzz', formula: '', aliases: [] },
+        { id: 'cpd05323', name: 'Glucoiberin', formula: '', aliases: [] },
+      ],
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const biochem = await import('@/lib/api/biochem');
+    const res = await biochem.getCompoundsFromModelseedApi({
+      limit: 10,
+      filterModel: {
+        items: [],
+        quickFilterValues: ['glucoiberin'],
+      },
+    });
+    expect(res.docs.map((d) => d.id)).toEqual(['cpd05323']);
+    expect(res.numFound).toBe(1);
   });
 });

--- a/tests/unit/api/biochem.test.ts
+++ b/tests/unit/api/biochem.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
 import * as biochemApi from '@/lib/api/biochem';
 
 const getErrorMessage = (error: unknown): string =>
@@ -46,5 +46,36 @@ describe('Biochem API Integration Tests', () => {
       expect(atp.name).toBeDefined();
       expect('smiles' in atp).toBe(true);
     }
+  });
+});
+
+describe('getCompounds Solr query shape', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('quick search must not reference ontology (undefined field on compounds_staging)', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ response: { numFound: 0, start: 0, docs: [] } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await biochemApi.getCompounds({
+      limit: 25,
+      offset: 0,
+      filterModel: { items: [], quickFilterValues: ['cpd05323'] },
+    });
+
+    expect(fetchMock).toHaveBeenCalled();
+    const calledUrl = String(fetchMock.mock.calls[0]?.[0] ?? '');
+    const u = new URL(calledUrl);
+    const qRaw = u.searchParams.get('q');
+    expect(qRaw).toBeTruthy();
+    const q = decodeURIComponent(qRaw ?? '');
+    expect(q).not.toMatch(/\bontology\b/i);
+    expect(q).toContain('cpd05323');
+    expect(q).toMatch(/formula|aliases|name|id/);
   });
 });

--- a/tests/unit/api/biochem.test.ts
+++ b/tests/unit/api/biochem.test.ts
@@ -49,6 +49,21 @@ describe('Biochem API Integration Tests', () => {
   });
 });
 
+describe('filterDocsByGridModel (shared local column filters)', () => {
+  it('filters rows using MUI string operators', async () => {
+    const { filterDocsByGridModel } = await import('@/lib/api/biochem');
+    const docs = [
+      { id: '1', name: 'Alpha' },
+      { id: '2', name: 'Beta' },
+    ] as Record<string, unknown>[];
+    const out = filterDocsByGridModel(docs, [
+      { field: 'name', operator: 'contains', value: 'lph' },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.id).toBe('1');
+  });
+});
+
 describe('getCompounds Solr query shape', () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/tests/unit/api/biochem.test.ts
+++ b/tests/unit/api/biochem.test.ts
@@ -94,3 +94,34 @@ describe('getCompounds Solr query shape', () => {
     expect(q).toMatch(/formula|aliases|name|id/);
   });
 });
+
+describe('getReactions Solr case-variant filters', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('expands lowercase equals filters with case variants', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ response: { numFound: 0, start: 0, docs: [] } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await biochemApi.getReactions({
+      limit: 25,
+      offset: 0,
+      filterModel: {
+        items: [{ field: 'status', operator: 'equals', value: 'ok' }],
+        logicOperator: 'and',
+        quickFilterValues: [],
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalled();
+    const calledUrl = String(fetchMock.mock.calls[0]?.[0] ?? '');
+    const q = decodeURIComponent(new URL(calledUrl).searchParams.get('q') ?? '');
+    expect(q).toContain('status:"ok"');
+    expect(q).toContain('status:"OK"');
+  });
+});


### PR DESCRIPTION
## Summary
- Fix compounds quick search regressions on Solr (`cpd05323`, case-insensitive terms like `glucoiberin`) by removing invalid `ontology` query clauses and tightening query handling.
- Harden `DataControlHeader` behavior across grid consumers (search/filter sync, pagination consistency, server/client filter handling on PATRIC and related pages).
- Improve UI fallbacks for missing compound structures by showing clear unavailable-image placeholders instead of blank tiles, and link subsystem reaction IDs to reaction detail routes.

## Test plan
- [x] `npm run test -- --run tests/unit/api/biochem.test.ts tests/unit/api/biochem-rest-filtering.test.ts`
- [x] `npx eslint components/layout/DataControlHeader.tsx components/build-model/PatricGenomesTable.tsx`
- [x] Manual verification of `/biochem/compounds` quick search (`cpd05323`, `glucoiberin`) and fallback rendering for compounds without structure data.

Made with [Cursor](https://cursor.com)