### PR TITLE
Sync staging: preserve server-grid filter state

### DIFF
--- a/components/build-model/PatricGenomesTable.tsx
+++ b/components/build-model/PatricGenomesTable.tsx
@@ -129,6 +129,21 @@ export default function PatricGenomesTable({ onSelectGenome, disabled = false }:
         [disabled, onSelectGenome],
     );
 
+    const handleToolbarApplyFilterModel = (model: GridFilterModel) => {
+        // Store the full multi-filter from the toolbar (bypasses grid truncation)
+        committedFilterItemsRef.current = model.items as GridFilterItem[];
+        committedLogicOperatorRef.current = model.logicOperator;
+
+        // Also update the local filterModel so the UI stays in sync
+        setFilterModel({
+            items: model.items,
+            logicOperator: model.logicOperator,
+            quickFilterValues: model.quickFilterValues ?? [],
+            quickFilterLogicOperator: model.quickFilterLogicOperator,
+        });
+        setPaginationModel((prev) => ({ ...prev, page: 0 }));
+    };
+
     return (
         <Box>
             {error && (
@@ -155,8 +170,14 @@ export default function PatricGenomesTable({ onSelectGenome, disabled = false }:
                     setFilterModel((prev) => {
                         const committed = committedFilterItemsRef.current;
                         const incomingItems = (next.items ?? []) as GridFilterItem[];
+                        // Only keep committed filters when:
+                        // 1. We have committed items
+                        // 2. Incoming count is LESS than committed (truncation)
+                        // 3. Incoming count is > 0 (not an intentional clear)
                         const shouldKeepCommitted =
-                            committed.length > 0 && incomingItems.length < committed.length;
+                            committed.length > 0 &&
+                            incomingItems.length < committed.length &&
+                            incomingItems.length > 0;
                         return {
                             items: shouldKeepCommitted ? committed : incomingItems,
                             logicOperator: shouldKeepCommitted
@@ -167,7 +188,8 @@ export default function PatricGenomesTable({ onSelectGenome, disabled = false }:
                         };
                     });
                     const incomingItems = (next.items ?? []) as GridFilterItem[];
-                    if (incomingItems.length >= committedFilterItemsRef.current.length) {
+                    // Only update committed refs if we're not clearing (incoming has items or was truncation)
+                    if (incomingItems.length > 0 || incomingItems.length >= committedFilterItemsRef.current.length) {
                         committedFilterItemsRef.current = incomingItems;
                         committedLogicOperatorRef.current = next.logicOperator;
                     }
@@ -175,6 +197,7 @@ export default function PatricGenomesTable({ onSelectGenome, disabled = false }:
                 }}
                 showToolbar
                 slots={{ toolbar: DataControlHeader }}
+                slotProps={{ toolbar: { onApplyFilterModel: handleToolbarApplyFilterModel } }}
                 hideFooter
                 disableRowSelectionOnClick
                 disableColumnMenu

--- a/components/layout/DataControlHeader.tsx
+++ b/components/layout/DataControlHeader.tsx
@@ -619,6 +619,16 @@ function ToolbarFilterEditor({ onApplyFilterModel }: { onApplyFilterModel?: (mod
             // Pass source:'toolbar' so handlers know this is an explicit user action,
             // not a Community Edition truncation event from the grid itself.
             onApplyFilterModel(fullModel, { source: 'toolbar' });
+
+            // Also update the grid's internal model so features like GridHighlightText
+            // and the filter button badge reflect the current search state.
+            // We pass a truncated model to avoid Community Edition limits.
+            apiRef.current.setFilterModel({
+                items: filledItems.slice(0, 1),
+                logicOperator: draftLogicOperator,
+                quickFilterValues,
+                quickFilterLogicOperator,
+            });
         } else {
             // Client-side page: let the grid apply item[0] for native row filtering.
             // Rows 2+ won't be applied by the grid, but they are stored in committedItemsRef.


### PR DESCRIPTION
## Summary
- Syncs latest `VibhavSetlur:staging` into `ModelSEED:staging`
- Carries the remaining commit not yet in upstream staging:
  - `18dcf9e` fix(ui): preserve grid state when using onApplyFilterModel for server pages

## Why
- Ensures server-backed DataGrid pages keep committed filter state while toolbar quick-filter changes are applied.
- Aligns behavior across biochem and build-model tables.

## Scope
- `components/layout/DataControlHeader.tsx`
- `components/build-model/PatricGenomesTable.tsx`

## Validation
- Branch sync verified:
  - `develop == staging == origin/develop == origin/staging`
- Upstream divergence before PR:
  - `upstream/staging...origin/staging = 0 1`

Made with [Cursor](https://cursor.com)