### PR TITLE
Staging sync: fix canonical model refs and FBA detail loading

### DIFF
--- a/app/fba/[...path]/page.tsx
+++ b/app/fba/[...path]/page.tsx
@@ -26,7 +26,7 @@ import Link from 'next/link';
 import { DataGrid, GridColDef, GridPaginationModel, GridSortModel } from '@mui/x-data-grid';
 import CloseIcon from '@mui/icons-material/Close';
 
-import { getModelFbaFromApi } from '@/lib/api/modelseed';
+import { getModelFbaDataFromApi, getModelFbaFromApi } from '@/lib/api/modelseed';
 import { useAuth } from '@/components/auth/AuthProvider';
 import { workspaceGet, workspaceLs, workspaceDownloadUrl, parseWorkspaceGetObject } from '@/lib/api/workspace';
 import { USE_MODELSEED_API } from '@/lib/api/config';
@@ -511,6 +511,13 @@ export default function FbaPage({ params }: { params: Promise<{ path: string[] }
             // Try model-level FBA from API first using base paths
             if (USE_MODELSEED_API) {
                 for (const candidate of apiCandidates) {
+                    try {
+                        const detail = await getModelFbaDataFromApi(candidate, fbaName);
+                        if (detail && isFbaObjectData(detail)) return detail;
+                    } catch {
+                        // Fall through to list endpoint.
+                    }
+
                     try {
                         const result = await getModelFbaFromApi(candidate);
                         const selected = pickFbaObject(result, workspacePath, fbaName);

--- a/app/model/[...path]/page.tsx
+++ b/app/model/[...path]/page.tsx
@@ -1438,29 +1438,27 @@ export default function ModelDetailPage({ params }: { params: Promise<{ path: st
         staleTime: 30_000,
     });
 
-    const modelFbaRef = useMemo(() => {
-        // Only fetch FBA if we're on a specific model, not a folder
-        // A model path should have at least 3 segments and NOT end with /modelseed
+    const modelApiRef = useMemo(() => {
+        // Only fetch model-linked data if we're on a specific model, not a folder.
         const segments = workspacePath.split('/').filter(Boolean);
-        if (segments.length >= 3 && !workspacePath.toLowerCase().endsWith('/modelseed')) {
-            const modelPath = workspacePath.endsWith('/model') ? workspacePath : `${workspacePath}/model`;
-            return modelPath;
+        if (segments.length < 3 || workspacePath.toLowerCase().endsWith('/modelseed')) {
+            return null;
         }
-        return null;
-    }, [workspacePath]);
+        return apiCandidates[0] ?? null;
+    }, [workspacePath, apiCandidates]);
 
     const { data: modelFba, error: modelFbaError, refetch: refetchModelFba } = useQuery({
-        queryKey: ['modelFba', USE_MODELSEED_API, modelFbaRef],
-        enabled: USE_MODELSEED_API && modelFbaRef !== null,
-        queryFn: async () => getModelFbaFromApi(modelFbaRef!),
+        queryKey: ['modelFba', USE_MODELSEED_API, modelApiRef],
+        enabled: USE_MODELSEED_API && modelApiRef !== null,
+        queryFn: async () => getModelFbaFromApi(modelApiRef!),
         retry: 0,
         staleTime: 0,
     });
 
     const { data: modelGapfills, error: modelGapfillsError, refetch: refetchModelGapfills } = useQuery({
-        queryKey: ['modelGapfills', USE_MODELSEED_API, modelFbaRef],
-        enabled: USE_MODELSEED_API && modelFbaRef !== null,
-        queryFn: async () => listModelGapfillsFromApi(modelFbaRef!),
+        queryKey: ['modelGapfills', USE_MODELSEED_API, modelApiRef],
+        enabled: USE_MODELSEED_API && modelApiRef !== null,
+        queryFn: async () => listModelGapfillsFromApi(modelApiRef!),
         retry: 0,
         staleTime: 0,
     });

--- a/app/model/[...path]/page.tsx
+++ b/app/model/[...path]/page.tsx
@@ -1444,8 +1444,16 @@ export default function ModelDetailPage({ params }: { params: Promise<{ path: st
         if (segments.length < 3 || workspacePath.toLowerCase().endsWith('/modelseed')) {
             return null;
         }
-        return apiCandidates[0] ?? null;
-    }, [workspacePath, apiCandidates]);
+        // modelseed-api expects the canonical model ref (without trailing /model).
+        const canonical = modelRootPath;
+        const expandedCanonical = expandOwnerRef(canonical, authMethod);
+        const canonicalCandidates = dedupeRefs([
+            expandedCanonical,
+            canonical,
+            ownerAliasRef(canonical, authMethod),
+        ]);
+        return canonicalCandidates[0] ?? null;
+    }, [workspacePath, modelRootPath, authMethod]);
 
     const { data: modelFba, error: modelFbaError, refetch: refetchModelFba } = useQuery({
         queryKey: ['modelFba', USE_MODELSEED_API, modelApiRef],

--- a/lib/api/modelseed.ts
+++ b/lib/api/modelseed.ts
@@ -279,6 +279,26 @@ export async function getModelFbaFromApi(ref: string): Promise<Record<string, un
     }
 }
 
+export async function getModelFbaDataFromApi(
+    ref: string,
+    fbaId: string,
+): Promise<Record<string, unknown> | null> {
+    try {
+        return await modelseedFetch<Record<string, unknown>>(
+            `/api/models/fba/data${buildQueryString({
+                ref: safeDecodePath(ref),
+                fba_id: safeDecodePath(fbaId),
+            })}`,
+        );
+    } catch (err) {
+        // 404 means no detail data exists yet for this FBA run
+        if (err instanceof Error && err.message.includes('(404)')) {
+            return null;
+        }
+        throw err;
+    }
+}
+
 export async function getModelDetailBundleFromApi(ref: string): Promise<ModelDetailBundle> {
     const [data, gapfills, fba] = await Promise.all([
         getModelDataFromApi(ref),

--- a/tests/unit/api/modelseed-client.test.ts
+++ b/tests/unit/api/modelseed-client.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+function setAuthToken(): void {
+    localStorage.setItem('auth', JSON.stringify({
+        user_id: 'testuser',
+        method: 'PATRIC',
+        token: 'test-token',
+    }));
+}
+
+describe('modelseed API client wrappers', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        vi.resetModules();
+        process.env.NEXT_PUBLIC_USE_MODELSEED_API = 'true';
+        process.env.NEXT_PUBLIC_MODELSEED_API_URL = 'http://localhost:8000';
+        localStorage.clear();
+        setAuthToken();
+    });
+
+    it('calls fba detail endpoint with ref and fba_id', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            new Response(JSON.stringify({ objectiveValue: 0.93, FBAReactionVariables: [] }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        );
+
+        const api = await import('@/lib/api/modelseed');
+        await api.getModelFbaDataFromApi('/jplfaria@patricbrc.org/modelseed/511145.12', 'fba.0');
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const url = String(fetchMock.mock.calls[0]?.[0] ?? '');
+        expect(url).toBe(
+            'http://localhost:8000/api/models/fba/data?ref=%2Fjplfaria%40patricbrc.org%2Fmodelseed%2F511145.12&fba_id=fba.0',
+        );
+    });
+
+    it('decodes already-encoded params before building query string', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            new Response(JSON.stringify({ objectiveValue: 0.93, FBAReactionVariables: [] }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        );
+
+        const api = await import('@/lib/api/modelseed');
+        await api.getModelFbaDataFromApi('%2Fjplfaria%40patricbrc.org%2Fmodelseed%2F511145.12', 'fba%2E0');
+
+        const url = String(fetchMock.mock.calls[0]?.[0] ?? '');
+        expect(url).toBe(
+            'http://localhost:8000/api/models/fba/data?ref=%2Fjplfaria%40patricbrc.org%2Fmodelseed%2F511145.12&fba_id=fba.0',
+        );
+    });
+
+    it('returns null when fba detail endpoint responds with 404', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            new Response(JSON.stringify({ detail: 'not found' }), {
+                status: 404,
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        );
+
+        const api = await import('@/lib/api/modelseed');
+        await expect(
+            api.getModelFbaDataFromApi('/jplfaria@patricbrc.org/modelseed/511145.12', 'fba.404'),
+        ).resolves.toBeNull();
+    });
+});

--- a/tests/unit/api/modelseed-client.test.ts
+++ b/tests/unit/api/modelseed-client.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 function setAuthToken(): void {
     localStorage.setItem('auth', JSON.stringify({
@@ -12,10 +12,14 @@ describe('modelseed API client wrappers', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
         vi.resetModules();
-        process.env.NEXT_PUBLIC_USE_MODELSEED_API = 'true';
-        process.env.NEXT_PUBLIC_MODELSEED_API_URL = 'http://localhost:8000';
+        vi.stubEnv('NEXT_PUBLIC_USE_MODELSEED_API', 'true');
+        vi.stubEnv('NEXT_PUBLIC_MODELSEED_API_URL', 'http://localhost:8000');
         localStorage.clear();
         setAuthToken();
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
     });
 
     it('calls fba detail endpoint with ref and fba_id', async () => {


### PR DESCRIPTION
## Summary
- Syncs latest `VibhavSetlur:staging` into `ModelSEED:staging`.
- Includes two commits focused on FBA/model-detail correctness and API client coverage.

## Included Commits
- `b93af2b` fix(model-detail): use canonical model ref for FBA and gapfills
- `5fda9ba` fix(fba-detail): load FBA detail data by fba_id

## Files Changed
- `app/model/[...path]/page.tsx`
- `app/fba/[...path]/page.tsx`
- `lib/api/modelseed.ts`
- `tests/unit/api/modelseed-client.test.ts`

## Why
- Ensures detail routes resolve against canonical model references.
- Prevents mismatches in FBA detail retrieval by using `fba_id` consistently.
- Adds unit-test coverage for affected client behavior to reduce regression risk.

## Validation
- Branch divergence reviewed against `upstream/staging`.
- Diff inspected for changed files and commit scope.

## Test plan
- [x] Unit tests for modelseed client changes are included in this branch.
- [ ] Verify model detail page renders FBA and gapfills with canonical refs.
- [ ] Verify FBA detail page loads by selected `fba_id` from model detail links.

Made with [Cursor](https://cursor.com)