### PR TITLE
Staging sync: shared toolbar filtering across data grids

### DIFF
--- a/app/(reference-data)/genomes/Annotations/page.tsx
+++ b/app/(reference-data)/genomes/Annotations/page.tsx
@@ -8,6 +8,7 @@ import Link from 'next/link';
 import { parseWorkspaceGetObject, workspaceGet } from '@/lib/api/workspace';
 import { USE_NEW_PROXY } from '@/lib/api/config';
 import DataControlHeader from '@/components/layout/DataControlHeader';
+import { useToolbarGridFiltering } from '@/lib/hooks/useToolbarGridFiltering';
 
 interface SubsystemItem {
     id: string; // role
@@ -184,13 +185,22 @@ export default function SubsystemsPage() {
         [],
     );
 
+    const {
+        filteredRows,
+        handleFilterModelChange,
+        handleToolbarApplyFilterModel,
+    } = useToolbarGridFiltering<SubsystemItem>({
+        rows,
+        onFilterApplied: () => setPaginationModel((prev) => ({ ...prev, page: 0 })),
+    });
+
     return (
         <>
             <Typography variant="h5" fontWeight={600} gutterBottom>
                 Subsystems
             </Typography>
             <DataGrid<SubsystemItem>
-                rows={rows}
+                rows={filteredRows}
                 columns={columns}
                 loading={isLoading}
                 pageSizeOptions={[10, 25, 50, 100]}
@@ -198,10 +208,15 @@ export default function SubsystemsPage() {
                 onPaginationModelChange={setPaginationModel}
                 sortModel={sortModel}
                 onSortModelChange={setSortModel}
+                filterMode="server"
+                onFilterModelChange={handleFilterModelChange}
                 showToolbar
                 slots={{ toolbar: DataControlHeader }}
                 slotProps={{
-                    toolbar: { showQuickFilter: true },
+                    toolbar: {
+                        showQuickFilter: true,
+                        onApplyFilterModel: handleToolbarApplyFilterModel,
+                    },
                 }}
                 hideFooter
                 disableColumnMenu

--- a/app/(reference-data)/genomes/page.tsx
+++ b/app/(reference-data)/genomes/page.tsx
@@ -8,6 +8,7 @@ import Alert from '@mui/material/Alert';
 import { workspaceLs } from '@/lib/api/workspace';
 import { USE_NEW_PROXY } from '@/lib/api/config';
 import DataControlHeader from '@/components/layout/DataControlHeader';
+import { useToolbarGridFiltering } from '@/lib/hooks/useToolbarGridFiltering';
 
 interface PlantModelItem {
     id: string;
@@ -102,6 +103,15 @@ export default function PlantsPage() {
         staleTime: 5 * 60 * 1000,
     });
 
+    const {
+        filteredRows,
+        handleFilterModelChange,
+        handleToolbarApplyFilterModel,
+    } = useToolbarGridFiltering<PlantModelItem>({
+        rows,
+        onFilterApplied: () => setPaginationModel((prev) => ({ ...prev, page: 0 })),
+    });
+
     return (
         <>
             <Typography variant="h5" fontWeight={600} gutterBottom>
@@ -111,7 +121,7 @@ export default function PlantsPage() {
                 PlantSEED v2.0<br />Update In Progress: Annotation and reconstruction services are temporarily offline for updates and will be restored shortly.
             </Alert>
             <DataGrid<PlantModelItem>
-                rows={rows}
+                rows={filteredRows}
                 columns={columns}
                 loading={isLoading}
                 pageSizeOptions={[10, 25, 50, 100]}
@@ -119,10 +129,15 @@ export default function PlantsPage() {
                 onPaginationModelChange={setPaginationModel}
                 sortModel={sortModel}
                 onSortModelChange={setSortModel}
+                filterMode="server"
+                onFilterModelChange={handleFilterModelChange}
                 showToolbar
                 slots={{ toolbar: DataControlHeader }}
                 slotProps={{
-                    toolbar: { showQuickFilter: true },
+                    toolbar: {
+                        showQuickFilter: true,
+                        onApplyFilterModel: handleToolbarApplyFilterModel,
+                    },
                 }}
                 hideFooter
                 disableColumnMenu

--- a/app/(reference-data)/list-media/page.tsx
+++ b/app/(reference-data)/list-media/page.tsx
@@ -10,6 +10,7 @@ import { workspaceLs } from '@/lib/api/workspace';
 import { listPublicMediaFromApi } from '@/lib/api/modelseed';
 import { USE_MODELSEED_API, USE_NEW_PROXY } from '@/lib/api/config';
 import DataControlHeader from '@/components/layout/DataControlHeader';
+import { useToolbarGridFiltering } from '@/lib/hooks/useToolbarGridFiltering';
 
 interface MediaItem {
     id: string;
@@ -95,13 +96,22 @@ export default function MediaPage() {
         { field: 'type', headerName: 'Type', width: 180 },
     ], []);
 
+    const {
+        filteredRows,
+        handleFilterModelChange,
+        handleToolbarApplyFilterModel,
+    } = useToolbarGridFiltering<MediaItem>({
+        rows,
+        onFilterApplied: () => setPaginationModel((prev) => ({ ...prev, page: 0 })),
+    });
+
     return (
         <>
             <Typography variant="h5" fontWeight={600} gutterBottom>
                 Media Formulations
             </Typography>
             <DataGrid<MediaItem>
-                rows={rows}
+                rows={filteredRows}
                 columns={columns}
                 loading={isLoading}
                 pageSizeOptions={[10, 25, 50, 100]}
@@ -109,10 +119,15 @@ export default function MediaPage() {
                 onPaginationModelChange={setPaginationModel}
                 sortModel={sortModel}
                 onSortModelChange={setSortModel}
+                filterMode="server"
+                onFilterModelChange={handleFilterModelChange}
                 showToolbar
                 slots={{ toolbar: DataControlHeader }}
                 slotProps={{
-                    toolbar: { showQuickFilter: true },
+                    toolbar: {
+                        showQuickFilter: true,
+                        onApplyFilterModel: handleToolbarApplyFilterModel,
+                    },
                 }}
                 hideFooter
                 disableColumnMenu

--- a/app/(user-data)/my-jobs/page.tsx
+++ b/app/(user-data)/my-jobs/page.tsx
@@ -26,6 +26,7 @@ import { USE_MODELSEED_API } from '@/lib/api/config';
 import AuthGuard from '@/components/auth/AuthGuard';
 import DataControlHeader from '@/components/layout/DataControlHeader';
 import ExportModal from '@/components/ui/ExportModal';
+import { useToolbarGridFiltering } from '@/lib/hooks/useToolbarGridFiltering';
 
 /* ---------- types ---------- */
 
@@ -322,6 +323,19 @@ function MyJobsContent() {
         },
     ], [handleRefreshJob]);
 
+    const handleFiltersApplied = useCallback(() => {
+        setPagination((prev) => ({ ...prev, page: 0 }));
+    }, []);
+
+    const {
+        filteredRows,
+        handleFilterModelChange,
+        handleToolbarApplyFilterModel,
+    } = useToolbarGridFiltering<JobRow>({
+        rows: jobRows,
+        onFilterApplied: handleFiltersApplied,
+    });
+
     const exportColumns = useMemo(() => [
         { field: 'id', headerName: 'Job ID', defaultSelected: true },
         { field: 'task', headerName: 'Task', defaultSelected: true },
@@ -394,7 +408,7 @@ function MyJobsContent() {
             )}
 
             <DataGrid<JobRow>
-                rows={jobRows}
+                rows={filteredRows}
                 columns={columns}
                 pageSizeOptions={[10, 25, 50, 100]}
                 paginationModel={pagination}
@@ -406,9 +420,16 @@ function MyJobsContent() {
                         sortModel: [{ field: 'submitted', sort: 'desc' }],
                     },
                 }}
+                filterMode="server"
+                onFilterModelChange={handleFilterModelChange}
                 showToolbar
                 slots={{ toolbar: DataControlHeader }}
-                slotProps={{ toolbar: { showQuickFilter: true } }}
+                slotProps={{
+                    toolbar: {
+                        showQuickFilter: true,
+                        onApplyFilterModel: handleToolbarApplyFilterModel,
+                    },
+                }}
                 hideFooter
                 disableRowSelectionOnClick
                 getRowId={(row) => row.id}

--- a/app/(user-data)/my-models/page.tsx
+++ b/app/(user-data)/my-models/page.tsx
@@ -39,6 +39,7 @@ import DownloadModelMenu from '@/components/ui/DownloadModelMenu';
 import DeleteModelModal from '@/components/ui/DeleteModelModal';
 import CopyModelModal from '@/components/ui/CopyModelModal';
 import DataControlHeader from '@/components/layout/DataControlHeader';
+import { useToolbarGridFiltering } from '@/lib/hooks/useToolbarGridFiltering';
 import {
     isActiveJobStatus,
     isTerminalJobStatus,
@@ -557,6 +558,20 @@ export default function MyModelsPage() {
         },
     ], [handleModelDeleted, recentJobByRow]);
 
+    const handleFiltersApplied = useCallback(() => {
+        setPaginationModel((prev) => ({ ...prev, page: 0 }));
+    }, []);
+
+    const {
+        filterModel,
+        filteredRows,
+        handleFilterModelChange,
+        handleToolbarApplyFilterModel,
+    } = useToolbarGridFiltering<MyModelItem>({
+        rows,
+        onFilterApplied: handleFiltersApplied,
+    });
+
     return (
         <AuthGuard>
             <Box sx={{ maxWidth: '1400px', mx: 'auto', display: 'flex', flexDirection: 'column', gap: 2 }}>
@@ -710,7 +725,7 @@ export default function MyModelsPage() {
                     </Typography>
                 ) : (
                     <DataGrid<MyModelItem>
-                        rows={rows}
+                        rows={filteredRows}
                         columns={columns}
                         loading={isLoading}
                         pageSizeOptions={[10, 25, 50, 100]}
@@ -723,10 +738,16 @@ export default function MyModelsPage() {
                                 sortModel: [{ field: 'modDate', sort: 'desc' }],
                             },
                         }}
+                        filterModel={filterModel}
+                        filterMode="server"
+                        onFilterModelChange={handleFilterModelChange}
                         showToolbar
                         slots={{ toolbar: DataControlHeader }}
                         slotProps={{
-                            toolbar: { showQuickFilter: true },
+                            toolbar: {
+                                showQuickFilter: true,
+                                onApplyFilterModel: handleToolbarApplyFilterModel,
+                            },
                         }}
                         hideFooter
                         disableColumnMenu

--- a/app/(user-data)/myMedia/page.tsx
+++ b/app/(user-data)/myMedia/page.tsx
@@ -21,6 +21,7 @@ import { useAuth } from '@/components/auth/AuthProvider';
 import DataControlHeader from '@/components/layout/DataControlHeader';
 import ExportModal from '@/components/ui/ExportModal';
 import { parseWorkspaceDate } from '@/lib/utils/date';
+import { useToolbarGridFiltering } from '@/lib/hooks/useToolbarGridFiltering';
 
 interface MyMediaItem {
     id: string;
@@ -197,6 +198,20 @@ export default function MyMediaPage() {
         },
     ], [exportingMediaId, isDeletingMedia, goToMediaPath]);
 
+    const handleFiltersApplied = useCallback(() => {
+        setPaginationModel((prev) => ({ ...prev, page: 0 }));
+    }, []);
+
+    const {
+        filterModel,
+        filteredRows,
+        handleFilterModelChange,
+        handleToolbarApplyFilterModel,
+    } = useToolbarGridFiltering<MyMediaItem>({
+        rows,
+        onFilterApplied: handleFiltersApplied,
+    });
+
     const exportColumns = useMemo(() => [
         { field: 'id', headerName: 'Media ID', defaultSelected: true },
         { field: 'name', headerName: 'Name', defaultSelected: true },
@@ -252,7 +267,7 @@ export default function MyMediaPage() {
                     </Typography>
                 ) : (
                     <DataGrid<MyMediaItem>
-                        rows={rows}
+                        rows={filteredRows}
                         columns={columns}
                         loading={isLoading}
                         pageSizeOptions={[10, 25, 50, 100]}
@@ -260,10 +275,16 @@ export default function MyMediaPage() {
                         onPaginationModelChange={setPaginationModel}
                         sortModel={sortModel}
                         onSortModelChange={setSortModel}
+                        filterModel={filterModel}
+                        filterMode="server"
+                        onFilterModelChange={handleFilterModelChange}
                         showToolbar
                         slots={{ toolbar: DataControlHeader }}
                         slotProps={{
-                            toolbar: { showQuickFilter: true },
+                            toolbar: {
+                                showQuickFilter: true,
+                                onApplyFilterModel: handleToolbarApplyFilterModel,
+                            },
                         }}
                         hideFooter
                         disableColumnMenu

--- a/components/build-model/PatricGenomesTable.tsx
+++ b/components/build-model/PatricGenomesTable.tsx
@@ -81,6 +81,8 @@ export default function PatricGenomesTable({ onSelectGenome, disabled = false }:
                 const filtered = filterDocsByGridModel(
                     raw.rows as unknown as Record<string, unknown>[],
                     filterModel.items ?? [],
+                    undefined,
+                    String(filterModel.logicOperator ?? '').toLowerCase() === 'or' ? 'or' : 'and',
                 ) as unknown as PatricGenome[];
                 const sm = sortModel[0];
                 const sorted = sm?.field

--- a/components/build-model/RastGenomesTable.tsx
+++ b/components/build-model/RastGenomesTable.tsx
@@ -8,6 +8,7 @@ import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import DataControlHeader from '@/components/layout/DataControlHeader';
 import { listRastGenomes, RastGenomeJob } from '@/lib/api/modelseed';
+import { useToolbarGridFiltering } from '@/lib/hooks/useToolbarGridFiltering';
 
 interface RastGenomesTableProps {
     onSelectGenome: (job: RastGenomeJob) => void;
@@ -60,6 +61,15 @@ export default function RastGenomesTable({ onSelectGenome, disabled = false }: R
         [disabled, onSelectGenome],
     );
 
+    const {
+        filteredRows,
+        handleFilterModelChange,
+        handleToolbarApplyFilterModel,
+    } = useToolbarGridFiltering<RastGenomeJob>({
+        rows,
+        onFilterApplied: () => setPaginationModel((prev) => ({ ...prev, page: 0 })),
+    });
+
     return (
         <Box>
             {error && (
@@ -69,7 +79,7 @@ export default function RastGenomesTable({ onSelectGenome, disabled = false }: R
             )}
             <DataGrid<RastGenomeJob>
                 autoHeight
-                rows={rows}
+                rows={filteredRows}
                 columns={columns}
                 loading={isLoading}
                 getRowId={(row) => row.id || row.genome_id}
@@ -78,8 +88,11 @@ export default function RastGenomesTable({ onSelectGenome, disabled = false }: R
                 onPaginationModelChange={setPaginationModel}
                 sortModel={sortModel}
                 onSortModelChange={setSortModel}
+                filterMode="server"
+                onFilterModelChange={handleFilterModelChange}
                 showToolbar
                 slots={{ toolbar: DataControlHeader }}
+                slotProps={{ toolbar: { onApplyFilterModel: handleToolbarApplyFilterModel } }}
                 hideFooter
                 disableRowSelectionOnClick
                 disableColumnMenu

--- a/components/layout/DataControlHeader.tsx
+++ b/components/layout/DataControlHeader.tsx
@@ -211,10 +211,22 @@ function ToolbarSearchField({ onApplyFilterModel }: { onApplyFilterModel?: (mode
             // For server-side pages: call the page's handler directly so the server
             // re-fetches with both column filters and the new quick search.
             if (typeof onApplyFilterModel === 'function') {
-                onApplyFilterModel(newModel, {});
+                onApplyFilterModel(newModel, { source: 'toolbar' });
+                // Update the grid's internal model so the input retains the committed value.
+                apiRef.current.setFilterModel({
+                    items: items.slice(0, 1),
+                    logicOperator,
+                    quickFilterValues: newModel.quickFilterValues,
+                    quickFilterLogicOperator: newModel.quickFilterLogicOperator,
+                });
             } else {
-                // Client-side: use setFilterModel normally (grid handles filtering in-memory).
-                apiRef.current.setFilterModel(newModel);
+                // Client-side: use setFilterModel normally, but truncate to 1 item to avoid CE limits.
+                apiRef.current.setFilterModel({
+                    items: items.slice(0, 1),
+                    logicOperator,
+                    quickFilterValues: newModel.quickFilterValues,
+                    quickFilterLogicOperator: newModel.quickFilterLogicOperator,
+                });
             }
         },
         [apiRef, onApplyFilterModel],

--- a/lib/api/biochem.ts
+++ b/lib/api/biochem.ts
@@ -575,7 +575,12 @@ async function fetchModelseedApiBiochem<T>(
 
     const filteredDocs = hasColumnFilters
         ? working.filter((doc) =>
-            matchesFilterModel(doc as Record<string, unknown>, filterModel?.items ?? [], endpoint))
+            matchesFilterModel(
+                doc as Record<string, unknown>,
+                filterModel?.items ?? [],
+                filterModel?.logicOperator === 'or' ? 'or' : 'and',
+                endpoint,
+            ))
         : working;
     const sortedDocs = sort ? sortDocs(filteredDocs, sort, resolveDocFieldKey) : filteredDocs;
     const pagedDocs = sortedDocs.slice(offset, offset + limit);
@@ -692,10 +697,14 @@ function matchesFilterItem(
 function matchesFilterModel(
     doc: Record<string, unknown>,
     items: GridFilterItem[],
+    logicOperator: 'and' | 'or' = 'and',
     endpoint?: string,
 ): boolean {
     const activeItems = items.filter((item) => item.field && item.operator);
     if (activeItems.length === 0) return true;
+    if (logicOperator === 'or') {
+        return activeItems.some((item) => matchesFilterItem(doc, item, endpoint));
+    }
     return activeItems.every((item) => matchesFilterItem(doc, item, endpoint));
 }
 
@@ -727,9 +736,10 @@ export function filterDocsByGridModel<T extends Record<string, unknown>>(
     docs: T[],
     items: GridFilterItem[],
     endpoint?: string,
+    logicOperator: 'and' | 'or' = 'and',
 ): T[] {
     if (!items.length) return docs;
-    return docs.filter((doc) => matchesFilterModel(doc, items, endpoint));
+    return docs.filter((doc) => matchesFilterModel(doc, items, logicOperator, endpoint));
 }
 
 /** Client-side sort helper for grids that batch-fetch then paginate (e.g. PATRIC with column filters). */

--- a/lib/hooks/useToolbarGridFiltering.ts
+++ b/lib/hooks/useToolbarGridFiltering.ts
@@ -1,0 +1,191 @@
+'use client';
+
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { GridFilterItem, GridFilterModel } from '@mui/x-data-grid';
+import { filterDocsByGridModel } from '@/lib/api/biochem';
+
+interface UseToolbarGridFilteringOptions<T extends object> {
+    rows: T[];
+    quickSearchFields?: Array<keyof T | string>;
+    endpoint?: string;
+    onFilterApplied?: () => void;
+}
+
+function normalizeFilterLogic(value: GridFilterModel['logicOperator']): 'and' | 'or' {
+    return String(value ?? '').toLowerCase() === 'or' ? 'or' : 'and';
+}
+
+function normalizeQuickFilterLogic(value: GridFilterModel['quickFilterLogicOperator']): 'and' | 'or' {
+    return String(value ?? '').toLowerCase() === 'or' ? 'or' : 'and';
+}
+
+function normalizeSearchTerms(values: GridFilterModel['quickFilterValues']): string[] {
+    if (!Array.isArray(values)) return [];
+    return values
+        .flatMap((value) => String(value ?? '').split(/\s+/))
+        .map((value) => value.trim().toLowerCase())
+        .filter(Boolean);
+}
+
+function normalizeQuickFilterValues(values: GridFilterModel['quickFilterValues']): string[] {
+    if (!Array.isArray(values)) return [];
+    return values
+        .map((value) => String(value ?? '').trim())
+        .filter(Boolean);
+}
+
+function areFilterItemsEqual(a: GridFilterItem[], b: GridFilterItem[]): boolean {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i += 1) {
+        const left = a[i];
+        const right = b[i];
+        if (!left || !right) return false;
+        if (String(left.field ?? '') !== String(right.field ?? '')) return false;
+        if (String(left.operator ?? '') !== String(right.operator ?? '')) return false;
+        if (JSON.stringify(left.value ?? null) !== JSON.stringify(right.value ?? null)) return false;
+    }
+    return true;
+}
+
+function areStringArraysEqual(a: string[] | undefined, b: string[] | undefined): boolean {
+    const left = a ?? [];
+    const right = b ?? [];
+    if (left.length !== right.length) return false;
+    for (let i = 0; i < left.length; i += 1) {
+        if (left[i] !== right[i]) return false;
+    }
+    return true;
+}
+
+function areFilterModelsEqual(a: GridFilterModel, b: GridFilterModel): boolean {
+    return (
+        areFilterItemsEqual((a.items ?? []) as GridFilterItem[], (b.items ?? []) as GridFilterItem[])
+        && normalizeFilterLogic(a.logicOperator) === normalizeFilterLogic(b.logicOperator)
+        && areStringArraysEqual(a.quickFilterValues as string[] | undefined, b.quickFilterValues as string[] | undefined)
+        && normalizeQuickFilterLogic(a.quickFilterLogicOperator) === normalizeQuickFilterLogic(b.quickFilterLogicOperator)
+    );
+}
+
+function normalizeCellValue(value: unknown): string {
+    if (Array.isArray(value)) return value.map((entry) => String(entry ?? '')).join(' ').toLowerCase();
+    if (value == null) return '';
+    if (value instanceof Date) return value.toISOString().toLowerCase();
+    if (typeof value === 'object') {
+        try {
+            return JSON.stringify(value).toLowerCase();
+        } catch {
+            return String(value).toLowerCase();
+        }
+    }
+    return String(value).toLowerCase();
+}
+
+export function filterRowsWithGridModel<T extends object>(
+    rows: T[],
+    filterModel: GridFilterModel,
+    options: {
+        quickSearchFields?: Array<keyof T | string>;
+        endpoint?: string;
+    } = {},
+): T[] {
+    if (!Array.isArray(rows) || rows.length === 0) return [];
+
+    const items = (filterModel.items ?? []) as GridFilterItem[];
+    const filteredByColumns = filterDocsByGridModel(
+        rows as unknown as Record<string, unknown>[],
+        items,
+        options.endpoint,
+        normalizeFilterLogic(filterModel.logicOperator),
+    ) as unknown as T[];
+
+    const terms = normalizeSearchTerms(filterModel.quickFilterValues);
+    if (terms.length === 0) return filteredByColumns;
+
+    const quickLogic = normalizeQuickFilterLogic(filterModel.quickFilterLogicOperator);
+    const resolvedFields = (options.quickSearchFields ?? []).map(String).filter(Boolean);
+
+    return filteredByColumns.filter((row) => {
+        const record = row as Record<string, unknown>;
+        const values = resolvedFields.length > 0
+            ? resolvedFields.map((field) => normalizeCellValue(record[field]))
+            : Object.values(record).map(normalizeCellValue);
+
+        const matchesTerm = (term: string) => values.some((value) => value.includes(term));
+        return quickLogic === 'or' ? terms.some(matchesTerm) : terms.every(matchesTerm);
+    });
+}
+
+export function useToolbarGridFiltering<T extends object>(
+    options: UseToolbarGridFilteringOptions<T>,
+) {
+    const {
+        rows,
+        quickSearchFields,
+        endpoint,
+        onFilterApplied,
+    } = options;
+    const [filterModel, setFilterModel] = useState<GridFilterModel>({ items: [], quickFilterValues: [] });
+    const committedFilterItemsRef = useRef<GridFilterItem[]>([]);
+    const committedQuickFilterValuesRef = useRef<string[]>([]);
+    const toolbarSaveRef = useRef(false);
+
+    const handleFilterModelChange = useCallback(
+        (next: GridFilterModel) => {
+            const incoming = (next.items ?? []) as GridFilterItem[];
+            const committed = committedFilterItemsRef.current;
+            const fromToolbar = toolbarSaveRef.current;
+            toolbarSaveRef.current = false;
+            const incomingQuickFilterValues = normalizeQuickFilterValues(next.quickFilterValues);
+
+            // Guard against Community DataGrid truncation events (unless user explicitly saved via toolbar).
+            if (!fromToolbar && incoming.length > 0 && incoming.length < committed.length) {
+                return;
+            }
+
+            const shouldPreserveQuickSearch =
+                !fromToolbar
+                && incomingQuickFilterValues.length === 0
+                && committedQuickFilterValuesRef.current.length > 0;
+
+            const resolvedQuickFilterValues = shouldPreserveQuickSearch
+                ? committedQuickFilterValuesRef.current
+                : incomingQuickFilterValues;
+
+            const nextModel: GridFilterModel = {
+                items: incoming,
+                logicOperator: next.logicOperator,
+                quickFilterValues: resolvedQuickFilterValues,
+                quickFilterLogicOperator: next.quickFilterLogicOperator,
+            };
+
+            setFilterModel((prev) => {
+                if (areFilterModelsEqual(prev, nextModel)) return prev;
+                return nextModel;
+            });
+            committedFilterItemsRef.current = incoming;
+            committedQuickFilterValuesRef.current = resolvedQuickFilterValues;
+            onFilterApplied?.();
+        },
+        [onFilterApplied],
+    );
+
+    const handleToolbarApplyFilterModel = useCallback(
+        (model: GridFilterModel) => {
+            toolbarSaveRef.current = true;
+            handleFilterModelChange(model);
+        },
+        [handleFilterModelChange],
+    );
+
+    const filteredRows = useMemo(
+        () => filterRowsWithGridModel(rows, filterModel, { quickSearchFields, endpoint }),
+        [rows, filterModel, quickSearchFields, endpoint],
+    );
+
+    return {
+        filterModel,
+        filteredRows,
+        handleFilterModelChange,
+        handleToolbarApplyFilterModel,
+    };
+}

--- a/tests/unit/utils/gridFiltering.test.ts
+++ b/tests/unit/utils/gridFiltering.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { GridFilterModel } from '@mui/x-data-grid';
+import { filterDocsByGridModel } from '@/lib/api/biochem';
+import { filterRowsWithGridModel } from '@/lib/hooks/useToolbarGridFiltering';
+
+describe('grid filtering helpers', () => {
+    it('supports OR logic for column filters', () => {
+        const rows = [
+            { id: 'm1', status: 'queued', type: 'model' },
+            { id: 'm2', status: 'completed', type: 'media' },
+            { id: 'm3', status: 'failed', type: 'job' },
+        ];
+
+        const filtered = filterDocsByGridModel(
+            rows,
+            [
+                { field: 'status', operator: 'equals', value: 'queued' },
+                { field: 'type', operator: 'equals', value: 'media' },
+            ],
+            undefined,
+            'or',
+        );
+
+        expect(filtered.map((row) => row.id)).toEqual(['m1', 'm2']);
+    });
+
+    it('applies quick search terms with AND logic by default', () => {
+        const rows = [
+            { id: 'm1', name: 'Escherichia coli model', source: 'PATRIC' },
+            { id: 'm2', name: 'Bacillus model', source: 'RAST' },
+            { id: 'm3', name: 'Escherichia reference', source: 'PlantSEED' },
+        ];
+
+        const model: GridFilterModel = {
+            items: [],
+            quickFilterValues: ['escherichia model'],
+        };
+
+        const filtered = filterRowsWithGridModel(rows, model, {
+            quickSearchFields: ['name', 'source'],
+        });
+
+        expect(filtered.map((row) => row.id)).toEqual(['m1']);
+    });
+
+    it('combines column filters with quick search', () => {
+        const rows = [
+            { id: 'm1', name: 'Athaliana Model', domain: 'plant', status: 'completed' },
+            { id: 'm2', name: 'Athaliana Draft', domain: 'plant', status: 'queued' },
+            { id: 'm3', name: 'Bacillus Model', domain: 'microbe', status: 'completed' },
+        ];
+
+        const model: GridFilterModel = {
+            items: [{ field: 'status', operator: 'equals', value: 'completed' }],
+            quickFilterValues: ['athaliana'],
+        };
+
+        const filtered = filterRowsWithGridModel(rows, model, {
+            quickSearchFields: ['name', 'domain'],
+        });
+
+        expect(filtered.map((row) => row.id)).toEqual(['m1']);
+    });
+});


### PR DESCRIPTION
## Summary
- Syncs latest `VibhavSetlur:staging` into `ModelSEED:staging`.
- Introduces a shared toolbar/grid filtering flow used across user and reference data tables.

## Included commits
- `6898d17` feat(filtering): add reusable toolbar filtering hook with OR-aware model evaluation
- `a0f3b94` refactor(toolbar): adopt shared filter hook across user/reference data grids

## Key changes
- Added `useToolbarGridFiltering` hook to centralize quick-search + column-filter behavior.
- Extended grid filtering logic to honor OR/AND logic consistently.
- Integrated shared filtering flow into genomes/media/jobs/models/RAST table pages.
- Updated DataControlHeader apply behavior for synchronized toolbar-originated updates.
- Added unit coverage for filtering helper behavior.

## Files touched
- `lib/hooks/useToolbarGridFiltering.ts`
- `lib/api/biochem.ts`
- `components/layout/DataControlHeader.tsx`
- `components/build-model/PatricGenomesTable.tsx`
- `components/build-model/RastGenomesTable.tsx`
- `app/(reference-data)/genomes/page.tsx`
- `app/(reference-data)/genomes/Annotations/page.tsx`
- `app/(reference-data)/list-media/page.tsx`
- `app/(user-data)/my-jobs/page.tsx`
- `app/(user-data)/my-models/page.tsx`
- `app/(user-data)/myMedia/page.tsx`
- `tests/unit/utils/gridFiltering.test.ts`

## Validation
- Typecheck: `npx tsc --noEmit`
- Branch sync verified (`staging == origin/staging`)

Made with [Cursor](https://cursor.com)