### PR TITLE
fix: update API status URL to use /PMS/api/health

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,11 +100,11 @@ NEXT_PUBLIC_REST_BASE_URL_PRODUCTION=https://modelseed.org/api/v0
 # No trailing slash.
 #
 # Override:       Required in manual mode, otherwise optional (mode default used)
-# Mode default:   staging=https://staging.modelseed.org/api/test-service | production=https://modelseed.org/api/test-service
-# Fallback:       {MODELSEED_SITE_BASE_URL}/api/test-service
+# Mode default:   staging=https://staging.modelseed.org/PMS/api/health | production=https://modelseed.org/PMS/api/health
+# Fallback:       {MODELSEED_SITE_BASE_URL}/PMS/api/health
 NEXT_PUBLIC_STATUS_API_URL=
-NEXT_PUBLIC_STATUS_API_URL_STAGING=https://staging.modelseed.org/api/test-service
-NEXT_PUBLIC_STATUS_API_URL_PRODUCTION=https://modelseed.org/api/test-service
+NEXT_PUBLIC_STATUS_API_URL_STAGING=https://staging.modelseed.org/PMS/api/health
+NEXT_PUBLIC_STATUS_API_URL_PRODUCTION=https://modelseed.org/PMS/api/health
 
 # =============================================================================
 # SOLR BASE URL

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -104,7 +104,7 @@ Base URL for the legacy ModelSEED REST v0 API.
 
 Status endpoint used by the `/about/version` page for build and service checks.
 
-- **Override:** Required in manual mode, optional otherwise
+- **Override:** Required in manual mode; when set explicitly, use `{MODELSEED_SITE_BASE_URL}/PMS/api/health`
 - **Mode defaults:** `staging=https://staging.modelseed.org/PMS/api/health` / `production=https://modelseed.org/PMS/api/health`
 - **Fallback:** `{MODELSEED_SITE_BASE_URL}/PMS/api/health`
 
@@ -246,7 +246,7 @@ NEXT_PUBLIC_DEPLOYMENT_MODE=manual
 NEXT_PUBLIC_SITE_BASE_URL=https://my-custom-host.example.com
 NEXT_PUBLIC_API_BASE_URL=https://my-custom-host.example.com/PMS
 NEXT_PUBLIC_REST_BASE_URL=https://my-custom-host.example.com/api/v0
-NEXT_PUBLIC_STATUS_API_URL=https://my-custom-host.example.com/api/test-service
+NEXT_PUBLIC_STATUS_API_URL=https://my-custom-host.example.com/PMS/api/health
 NEXT_PUBLIC_SOLR_BASE_URL=https://my-custom-host.example.com/solr/
 NEXT_PUBLIC_SOLR_REACTIONS_COLLECTION=reactions
 NEXT_PUBLIC_SOLR_COMPOUNDS_COLLECTION=compounds

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -105,8 +105,8 @@ Base URL for the legacy ModelSEED REST v0 API.
 Status endpoint used by the `/about/version` page for build and service checks.
 
 - **Override:** Required in manual mode, optional otherwise
-- **Mode defaults:** `staging=https://staging.modelseed.org/api/test-service` / `production=https://modelseed.org/api/test-service`
-- **Fallback:** `{MODELSEED_SITE_BASE_URL}/api/test-service`
+- **Mode defaults:** `staging=https://staging.modelseed.org/PMS/api/health` / `production=https://modelseed.org/PMS/api/health`
+- **Fallback:** `{MODELSEED_SITE_BASE_URL}/PMS/api/health`
 
 ---
 

--- a/lib/api/config.ts
+++ b/lib/api/config.ts
@@ -192,8 +192,8 @@ export const MODELSEED_API_TEST_URL = stripTrailingSlash(
         overrideVar: 'NEXT_PUBLIC_STATUS_API_URL',
         stagingDefaultVar: 'NEXT_PUBLIC_STATUS_API_URL_STAGING',
         productionDefaultVar: 'NEXT_PUBLIC_STATUS_API_URL_PRODUCTION',
-        stagingFallback: () => `${MODELSEED_SITE_BASE_URL}/api/test-service`,
-        productionFallback: () => `${MODELSEED_SITE_BASE_URL}/api/test-service`,
+        stagingFallback: () => `${MODELSEED_SITE_BASE_URL}/PMS/api/health`,
+        productionFallback: () => `${MODELSEED_SITE_BASE_URL}/PMS/api/health`,
         manualDescription: 'status check endpoint used by /about/version',
     }),
 );

--- a/tests/unit/api/config.test.ts
+++ b/tests/unit/api/config.test.ts
@@ -34,13 +34,14 @@ describe('api config deployment resolution', () => {
         vi.stubEnv('NEXT_PUBLIC_SITE_BASE_URL', 'https://custom.modelseed.org');
         vi.stubEnv('NEXT_PUBLIC_API_BASE_URL', 'https://custom.modelseed.org/PMS');
         vi.stubEnv('NEXT_PUBLIC_REST_BASE_URL', 'https://custom.modelseed.org/api/v0');
-        vi.stubEnv('NEXT_PUBLIC_STATUS_API_URL', 'https://custom.modelseed.org/api/test-service');
+        vi.stubEnv('NEXT_PUBLIC_STATUS_API_URL', 'https://custom.modelseed.org/PMS/api/health');
         vi.stubEnv('NEXT_PUBLIC_SOLR_BASE_URL', 'https://custom.modelseed.org/solr');
         vi.stubEnv('NEXT_PUBLIC_SOLR_REACTIONS_COLLECTION', 'reactions_custom');
         vi.stubEnv('NEXT_PUBLIC_SOLR_COMPOUNDS_COLLECTION', 'compounds_custom');
         const config = await loadConfig();
         expect(config.DEPLOYMENT_MODE).toBe('manual');
         expect(config.MODELSEED_API_URL).toBe('https://custom.modelseed.org/PMS');
+        expect(config.MODELSEED_API_TEST_URL).toBe('https://custom.modelseed.org/PMS/api/health');
         expect(config.SOLR_BASE).toBe('https://custom.modelseed.org/solr/');
     });
 
@@ -49,6 +50,7 @@ describe('api config deployment resolution', () => {
         const config = await loadConfig();
         expect(config.DEPLOYMENT_MODE).toBe('staging');
         expect(config.MODELSEED_SITE_BASE_URL).toBe('https://staging.modelseed.org');
+        expect(config.MODELSEED_API_TEST_URL).toBe('https://staging.modelseed.org/PMS/api/health');
         expect(config.SOLR_REACTIONS_COLLECTION).toBe('reactions_staging');
     });
 
@@ -58,6 +60,7 @@ describe('api config deployment resolution', () => {
         const config = await loadConfig();
         expect(config.DEPLOYMENT_MODE).toBe('production');
         expect(config.MODELSEED_API_URL).toBe('https://modelseed.org/PMS');
+        expect(config.MODELSEED_API_TEST_URL).toBe('https://modelseed.org/PMS/api/health');
         expect(config.SOLR_REACTIONS_COLLECTION).toBe('reactions');
         expect(config.SOLR_COMPOUNDS_COLLECTION).toBe('compounds');
     });


### PR DESCRIPTION
Updates the default status API URL from `/api/test-service` to `/PMS/api/health` to fix the 502 error on the `/about/version` page. The old URL routed to a legacy Perl backend that no longer exists.