### PR TITLE
feat(jobs): render structured job-error bodies on submit and /my-jobs

### DIFF
--- a/app/(build-model)/plant/page.tsx
+++ b/app/(build-model)/plant/page.tsx
@@ -24,6 +24,9 @@ import PatricGenomesTable from '@/components/build-model/PatricGenomesTable';
 import RastGenomePreviewDialog from '@/components/build-model/RastGenomePreviewDialog';
 import RastGenomesTable from '@/components/build-model/RastGenomesTable';
 import { PatricGenome } from '@/lib/api/patric';
+import { presentJobSubmitError, type PresentedJobSubmitError } from '@/lib/utils/jobErrors';
+import { useTokenExpiredRedirect } from '@/lib/hooks/useTokenExpiredRedirect';
+import JobSubmitErrorAlert from '@/components/ui/JobSubmitErrorAlert';
 
 /**
  * When true, the PlantSEED build pipeline is disabled in the UI.
@@ -100,9 +103,11 @@ export default function BuildModelPlantPage() {
     const [uploadForm, setUploadForm] = useState<MicrobeUploadForm>(DEFAULT_UPLOAD_FORM);
     const [submitting, setSubmitting] = useState<SubmissionKey>(null);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [errorPresented, setErrorPresented] = useState<PresentedJobSubmitError | null>(null);
     const [successMessage, setSuccessMessage] = useState<string | null>(null);
     const [plantseedDialogOpen, setPlantseedDialogOpen] = useState(false);
     const [selectedRastJob, setSelectedRastJob] = useState<RastGenomeJob | null>(null);
+    const maybeRedirectOnTokenExpiry = useTokenExpiredRedirect();
 
     const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
         if (PLANTSEED_MAINTENANCE && newValue === 0) {
@@ -121,6 +126,7 @@ export default function BuildModelPlantPage() {
     ) => {
         setSubmitting(key);
         setErrorMessage(null);
+        setErrorPresented(null);
         setSuccessMessage(null);
 
         try {
@@ -142,8 +148,9 @@ export default function BuildModelPlantPage() {
                     : 'Reconstruct job submitted successfully.',
             );
         } catch (err) {
-            const message = err instanceof Error ? err.message : 'Failed to submit reconstruct job';
-            setErrorMessage(message);
+            const presented = presentJobSubmitError(err);
+            if (maybeRedirectOnTokenExpiry(presented)) return;
+            setErrorPresented(presented);
         } finally {
             setSubmitting(null);
         }
@@ -252,6 +259,14 @@ export default function BuildModelPlantPage() {
                         Users can reconstruct models from public databases like PATRIC and RAST or upload their own annotated sequences for comprehensive metabolic analysis.
                     </Typography>
                 </Box>
+
+                {errorPresented && (
+                    <JobSubmitErrorAlert
+                        presented={errorPresented}
+                        onClose={() => setErrorPresented(null)}
+                        sx={{ mt: 0, mb: 3 }}
+                    />
+                )}
 
                 {(errorMessage || successMessage) && (
                     <Alert severity={errorMessage ? 'error' : 'success'} sx={{ mb: 3 }}>

--- a/app/(user-data)/my-jobs/page.tsx
+++ b/app/(user-data)/my-jobs/page.tsx
@@ -27,6 +27,7 @@ import { USE_MODELSEED_API } from '@/lib/api/config';
 import AuthGuard from '@/components/auth/AuthGuard';
 import DataControlHeader, { withQuickSearchHeaders } from '@/components/layout/DataControlHeader';
 import ExportModal from '@/components/ui/ExportModal';
+import FailedJobDetailsDialog, { type FailedJobDetails } from '@/components/ui/FailedJobDetailsDialog';
 import { useToolbarGridFiltering } from '@/lib/hooks/useToolbarGridFiltering';
 
 /* ---------- types ---------- */
@@ -43,6 +44,10 @@ interface JobRow {
     errorMsg?: string;
     outputPath?: string;
     app?: string;
+    /** Last progress note returned by the API (e.g. "Saving model…"). */
+    progress?: string;
+    /** Flattened `parameters.arguments` for the failed-job detail panel. */
+    parameters?: Record<string, unknown>;
 }
 
 interface JobStatusHistory {
@@ -144,6 +149,9 @@ function mergeApiAndTrackedJobs(
         const modelArg = typeof args?.model === 'string' ? String(args.model) : undefined;
         const errorMsg = formatJobError(job.error, modelArg);
         const app = String(params?.command ?? job.app ?? job.type ?? 'Unknown');
+        const progress = typeof job.progress === 'string' && job.progress
+            ? String(job.progress)
+            : undefined;
 
         rows.push({
             id,
@@ -157,6 +165,8 @@ function mergeApiAndTrackedJobs(
             errorMsg,
             outputPath,
             app,
+            progress,
+            parameters: args,
         });
     }
 
@@ -189,6 +199,19 @@ function MyJobsContent() {
     const statusHistoryRef = useRef<Map<string, JobStatusHistory>>(new Map());
 
     const [exportModalOpen, setExportModalOpen] = useState(false);
+    const [failedJobDetails, setFailedJobDetails] = useState<FailedJobDetails | null>(null);
+
+    const openFailedJobDialog = useCallback((row: JobRow) => {
+        setFailedJobDetails({
+            id: row.id,
+            app: row.app,
+            status: row.status,
+            progress: row.progress,
+            errorMsg: row.errorMsg,
+            parameters: row.parameters,
+            outputPath: row.outputPath,
+        });
+    }, []);
 
     const { data: jobRows = [], isLoading, error, refetch } = useQuery({
         queryKey: ['myJobs'],
@@ -276,17 +299,37 @@ function MyJobsContent() {
             field: 'status',
             headerName: 'Status',
             width: 180,
-            renderCell: (p) => (
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            renderCell: (p) => {
+                const isFailed = p.row.rawStatus.toLowerCase() === 'failed';
+                const chip = (
                     <Chip
                         label={p.row.isStuck ? `${p.row.status} (possibly stuck)` : p.row.status}
                         size="small"
                         color={statusColor(p.row.status, p.row.isStuck)}
                         variant="outlined"
                         icon={p.row.isStuck ? <WarningAmberIcon /> : undefined}
+                        onClick={isFailed ? () => openFailedJobDialog(p.row) : undefined}
+                        sx={isFailed ? { cursor: 'pointer' } : undefined}
+                        data-failed-job-chip={isFailed ? 'true' : undefined}
                     />
-                </Box>
-            ),
+                );
+
+                return (
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                        {isFailed ? (
+                            <Tooltip
+                                title={p.row.errorMsg
+                                    ? `${p.row.errorMsg.slice(0, 220)}${p.row.errorMsg.length > 220 ? '…' : ''} (click for details)`
+                                    : 'Job failed. Click for details.'}
+                            >
+                                {chip}
+                            </Tooltip>
+                        ) : (
+                            chip
+                        )}
+                    </Box>
+                );
+            },
         },
         {
             field: 'actions',
@@ -303,10 +346,13 @@ function MyJobsContent() {
                         </Tooltip>
                     )}
                     {p.row.rawStatus.toLowerCase() === 'failed' && (
-                        <Tooltip title={p.row.errorMsg || "Job failed. No error details provided by API."}>
+                        <Tooltip title="View error details">
                             <IconButton
                                 size="small"
                                 color="error"
+                                onClick={() => openFailedJobDialog(p.row)}
+                                aria-label="View failed job details"
+                                data-testid={`open-failed-job-${p.row.id}`}
                             >
                                 <InfoOutlinedIcon fontSize="small" />
                             </IconButton>
@@ -327,7 +373,7 @@ function MyJobsContent() {
                 </Box>
             ),
         },
-    ], [handleRefreshJob]);
+    ], [handleRefreshJob, openFailedJobDialog]);
 
     const handleFiltersApplied = useCallback(() => {
         setPagination((prev) => ({ ...prev, page: 0 }));
@@ -453,6 +499,12 @@ function MyJobsContent() {
                     No jobs found. Submit an FBA, Gapfill, or Reconstruction job to see it here.
                 </Typography>
             )}
+
+            <FailedJobDetailsDialog
+                open={failedJobDetails !== null}
+                onClose={() => setFailedJobDetails(null)}
+                job={failedJobDetails}
+            />
 
             <ExportModal
                 open={exportModalOpen}

--- a/app/(user-data)/my-models/page.tsx
+++ b/app/(user-data)/my-models/page.tsx
@@ -50,6 +50,9 @@ import {
     TrackedJob,
 } from '@/lib/api/jobTracker';
 import { parseWorkspaceDate } from '@/lib/utils/date';
+import { presentJobSubmitError, type PresentedJobSubmitError } from '@/lib/utils/jobErrors';
+import { useTokenExpiredRedirect } from '@/lib/hooks/useTokenExpiredRedirect';
+import JobSubmitErrorAlert from '@/components/ui/JobSubmitErrorAlert';
 
 interface MyModelItem {
     id: string; // Model name / filename
@@ -111,6 +114,8 @@ export default function MyModelsPage() {
     const [mergeOutputPath, setMergeOutputPath] = useState('');
     const [isSubmittingMerge, setIsSubmittingMerge] = useState(false);
     const [mergeMessage, setMergeMessage] = useState<string | null>(null);
+    const [mergeErrorPresented, setMergeErrorPresented] = useState<PresentedJobSubmitError | null>(null);
+    const maybeRedirectOnTokenExpiry = useTokenExpiredRedirect();
     const [trackedJobs, setTrackedJobs] = useState<TrackedJob[]>([]);
     const [jobActionError, setJobActionError] = useState<string | null>(null);
     const [copyModalOpen, setCopyModalOpen] = useState(false);
@@ -411,6 +416,7 @@ export default function MyModelsPage() {
         }
 
         setMergeMessage(null);
+        setMergeErrorPresented(null);
         setIsSubmittingMerge(true);
         try {
             const payload = await submitMergeJobFromApi({
@@ -438,12 +444,13 @@ export default function MyModelsPage() {
             setMergeDialogOpen(false);
             setSelectedModelIds([]);
         } catch (err) {
-            const message = err instanceof Error ? err.message : 'Failed to submit merge job';
-            setMergeMessage(message);
+            const presented = presentJobSubmitError(err);
+            if (maybeRedirectOnTokenExpiry(presented)) return;
+            setMergeErrorPresented(presented);
         } finally {
             setIsSubmittingMerge(false);
         }
-    }, [mergeModelName, mergeOutputPath, selectedModels]);
+    }, [mergeModelName, mergeOutputPath, selectedModels, maybeRedirectOnTokenExpiry]);
 
     const columns = useMemo<GridColDef<MyModelItem>[]>(() => [
         {
@@ -691,6 +698,14 @@ export default function MyModelsPage() {
                             )}
                         </Stack>
                     </Alert>
+                )}
+
+                {mergeErrorPresented && (
+                    <JobSubmitErrorAlert
+                        presented={mergeErrorPresented}
+                        onClose={() => setMergeErrorPresented(null)}
+                        sx={{ mt: 0 }}
+                    />
                 )}
 
                 {mergeMessage && (

--- a/app/model/[...path]/page.tsx
+++ b/app/model/[...path]/page.tsx
@@ -53,7 +53,8 @@ import {
     type TrackedJob,
 } from '@/lib/api/jobTracker';
 import { parseWorkspaceDate } from '@/lib/utils/date';
-import { formatJobError } from '@/lib/utils/jobErrors';
+import { formatJobError, presentJobSubmitError } from '@/lib/utils/jobErrors';
+import { useTokenExpiredRedirect } from '@/lib/hooks/useTokenExpiredRedirect';
 import ModelDetailHeader from '@/components/ui/ModelDetailHeader';
 import type { FbaAdvancedOptions } from '@/components/ui/MediaSelectionDialog';
 import DownloadModelMenu from '@/components/ui/DownloadModelMenu';
@@ -1620,6 +1621,8 @@ export default function ModelDetailPage({ params }: { params: Promise<{ path: st
     const [sortByTab, setSortByTab] = useState<Record<string, GridSortModel>>({});
     const [actionLoading, setActionLoading] = useState<'fba' | 'gapfill' | null>(null);
     const [actionMessage, setActionMessage] = useState<string | null>(null);
+    const [actionError, setActionError] = useState<ReturnType<typeof presentJobSubmitError> | null>(null);
+    const maybeRedirectOnTokenExpiry = useTokenExpiredRedirect();
     const [editReactionId, setEditReactionId] = useState('');
     const [editSummary, setEditSummary] = useState('');
     const [editSubmitting, setEditSubmitting] = useState(false);
@@ -2042,6 +2045,7 @@ export default function ModelDetailPage({ params }: { params: Promise<{ path: st
     const submitModelJob = async (kind: 'fba' | 'gapfill', media?: string, advancedOptions?: FbaAdvancedOptions) => {
         setActionLoading(kind);
         setActionMessage(null);
+        setActionError(null);
         const selectedMedia = media || defaultMedia;
         const modelRef = workspaceCandidates[0];
         try {
@@ -2100,8 +2104,9 @@ export default function ModelDetailPage({ params }: { params: Promise<{ path: st
                     : `${kind === 'fba' ? 'FBA' : 'Gapfill'} job submitted.`,
             );
         } catch (err) {
-            const raw = err instanceof Error ? err.message : `Failed to submit ${kind} job`;
-            setActionMessage(formatJobError(raw, modelRef) ?? raw);
+            const presented = presentJobSubmitError(err, { modelRef });
+            if (maybeRedirectOnTokenExpiry(presented)) return;
+            setActionError(presented);
         } finally {
             setActionLoading(null);
         }
@@ -2217,6 +2222,8 @@ export default function ModelDetailPage({ params }: { params: Promise<{ path: st
                 onRunGapfill={(mediaId?: string, mediaName?: string) => void submitModelJob('gapfill', mediaName)}
                 actionLoading={actionLoading}
                 actionMessage={actionMessage}
+                actionError={actionError}
+                onDismissActionError={() => setActionError(null)}
                 isPlantModel={isPlantModel}
             />
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -88,6 +88,8 @@ function HomePageContent() {
     const searchParams = useSearchParams();
     const { login, isAuthenticated, user, loading } = useAuth();
 
+    const sessionExpired = searchParams.get('reason') === 'token_expired';
+
     const currentMethod = AUTH_METHODS[method];
     const altMethod = method === 'rast' ? 'patric' : 'rast';
 
@@ -182,6 +184,12 @@ function HomePageContent() {
                                         <Typography variant="h6" sx={{ mb: 2 }}>
                                             Sign in with {currentMethod.name} account to continue
                                         </Typography>
+                                        {sessionExpired && !error && (
+                                            <Alert severity="warning" sx={{ mb: 2 }} data-testid="session-expired-notice">
+                                                <AlertTitle>Session expired</AlertTitle>
+                                                Your sign-in token expired. Sign in again to continue where you left off.
+                                            </Alert>
+                                        )}
                                         {error && (
                                             <Alert severity="error" sx={{ mb: 2 }}>
                                                 <AlertTitle>Error</AlertTitle>

--- a/components/ui/FailedJobDetailsDialog.tsx
+++ b/components/ui/FailedJobDetailsDialog.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Divider from '@mui/material/Divider';
+import Link from 'next/link';
+
+export interface FailedJobDetails {
+    id: string;
+    app?: string;
+    status: string;
+    progress?: string;
+    errorMsg?: string;
+    parameters?: Record<string, unknown>;
+    outputPath?: string;
+}
+
+interface FailedJobDetailsDialogProps {
+    open: boolean;
+    onClose: () => void;
+    job: FailedJobDetails | null;
+}
+
+function renderParametersBlock(parameters: Record<string, unknown> | undefined) {
+    if (!parameters || Object.keys(parameters).length === 0) {
+        return (
+            <Typography variant="body2" color="text.secondary">
+                No parameters recorded.
+            </Typography>
+        );
+    }
+
+    let pretty: string;
+    try {
+        pretty = JSON.stringify(parameters, null, 2);
+    } catch {
+        pretty = String(parameters);
+    }
+
+    return (
+        <Box
+            component="pre"
+            sx={{
+                m: 0,
+                p: 1.5,
+                bgcolor: 'grey.100',
+                borderRadius: 1,
+                fontFamily: 'monospace',
+                fontSize: 12,
+                maxHeight: 240,
+                overflow: 'auto',
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+            }}
+        >
+            {pretty}
+        </Box>
+    );
+}
+
+/**
+ * Detail panel for a failed job row — surfaces the full `job.error` string,
+ * the last progress note, parameters, and a deep link back to the targeted
+ * model when one is recorded. Implements the "Better" treatment described in
+ * docs/JOB_ERROR_UI_INTEGRATION.md (modelseed-api repo).
+ */
+export default function FailedJobDetailsDialog({
+    open,
+    onClose,
+    job,
+}: FailedJobDetailsDialogProps) {
+    if (!job) return null;
+
+    return (
+        <Dialog
+            open={open}
+            onClose={onClose}
+            maxWidth="md"
+            fullWidth
+            data-testid="failed-job-details-dialog"
+        >
+            <DialogTitle>
+                <Typography component="div" variant="h6" fontWeight={600}>
+                    Failed job details
+                </Typography>
+                <Typography component="div" variant="caption" color="text.secondary">
+                    {job.app ? `${job.app} · ` : ''}Job ID: {job.id}
+                </Typography>
+            </DialogTitle>
+
+            <DialogContent dividers>
+                <Box sx={{ mb: 2 }}>
+                    <Typography variant="overline" color="text.secondary">
+                        Error
+                    </Typography>
+                    <Box
+                        sx={{
+                            mt: 0.5,
+                            p: 1.5,
+                            bgcolor: '#fff4f4',
+                            border: '1px solid #f5c2c0',
+                            borderRadius: 1,
+                            fontFamily: 'monospace',
+                            fontSize: 13,
+                            color: '#5b1a16',
+                            maxHeight: 200,
+                            overflow: 'auto',
+                            whiteSpace: 'pre-wrap',
+                            wordBreak: 'break-word',
+                        }}
+                        data-testid="failed-job-error-text"
+                    >
+                        {job.errorMsg || 'No error details provided by the backend for this job.'}
+                    </Box>
+                </Box>
+
+                {job.progress && (
+                    <Box sx={{ mb: 2 }}>
+                        <Typography variant="overline" color="text.secondary">
+                            Last progress note
+                        </Typography>
+                        <Typography variant="body2" sx={{ mt: 0.5 }}>
+                            {job.progress}
+                        </Typography>
+                    </Box>
+                )}
+
+                <Divider sx={{ my: 2 }} />
+
+                <Box sx={{ mb: 1 }}>
+                    <Typography variant="overline" color="text.secondary">
+                        Parameters
+                    </Typography>
+                </Box>
+                {renderParametersBlock(job.parameters)}
+
+                {job.outputPath && (
+                    <Box sx={{ mt: 2 }}>
+                        <Typography variant="overline" color="text.secondary" display="block">
+                            Target model
+                        </Typography>
+                        <Link
+                            href={`/model${job.outputPath}`}
+                            style={{ color: '#00acc1', textDecoration: 'none', fontWeight: 500 }}
+                        >
+                            {job.outputPath}
+                        </Link>
+                    </Box>
+                )}
+            </DialogContent>
+
+            <DialogActions>
+                <Button onClick={onClose}>Close</Button>
+            </DialogActions>
+        </Dialog>
+    );
+}

--- a/components/ui/JobSubmitErrorAlert.tsx
+++ b/components/ui/JobSubmitErrorAlert.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+
+import type { PresentedJobSubmitError } from '@/lib/utils/jobErrors';
+
+interface JobSubmitErrorAlertProps {
+    /** Result from `presentJobSubmitError()`. */
+    presented: PresentedJobSubmitError;
+    /** Optional dismiss callback; renders an X when provided. */
+    onClose?: () => void;
+    /** Overrides default `sx={{ mt: 2 }}`. */
+    sx?: object;
+}
+
+/**
+ * Renders a job-submit error with the layout the modelseed-api integration
+ * doc asks for: `message` as the title, `hint` in lighter weight underneath,
+ * and a small `Input: <field>` caption when the backend pinpointed an input
+ * field. Use the legacy single-string Alert if the caller doesn't have a
+ * structured presented error yet.
+ */
+export default function JobSubmitErrorAlert({
+    presented,
+    onClose,
+    sx,
+}: JobSubmitErrorAlertProps) {
+    return (
+        <Alert
+            severity="error"
+            onClose={onClose}
+            sx={{ mt: 2, ...sx }}
+            data-error-code={presented.code ?? 'UNSTRUCTURED'}
+        >
+            <AlertTitle sx={{ whiteSpace: 'pre-line', mb: presented.hint || presented.field ? 0.5 : 0 }}>
+                {presented.message}
+            </AlertTitle>
+            {presented.hint && (
+                <Typography
+                    variant="body2"
+                    sx={{ color: 'text.secondary', whiteSpace: 'pre-line' }}
+                >
+                    {presented.hint}
+                </Typography>
+            )}
+            {presented.field && (
+                <Box sx={{ mt: 0.75 }}>
+                    <Typography variant="caption" color="text.secondary">
+                        Affected input: <strong>{presented.field}</strong>
+                    </Typography>
+                </Box>
+            )}
+        </Alert>
+    );
+}

--- a/components/ui/ModelDetailHeader.tsx
+++ b/components/ui/ModelDetailHeader.tsx
@@ -10,6 +10,8 @@ import MenuItem from '@mui/material/MenuItem';
 import FormControl from '@mui/material/FormControl';
 import Alert from '@mui/material/Alert';
 import MediaSelectionDialog, { type FbaAdvancedOptions } from './MediaSelectionDialog';
+import JobSubmitErrorAlert from './JobSubmitErrorAlert';
+import type { PresentedJobSubmitError } from '@/lib/utils/jobErrors';
 
 interface ModelReaction {
     id: string;
@@ -26,6 +28,14 @@ interface ModelDetailHeaderProps {
     onRunGapfill?: (mediaId?: string, mediaName?: string) => void;
     actionLoading?: 'fba' | 'gapfill' | null;
     actionMessage?: string | null;
+    /**
+     * Structured job-submit error from the modelseed-api pre-flight check
+     * (see docs/JOB_ERROR_UI_INTEGRATION.md). When set, takes precedence over
+     * `actionMessage` so the user sees the API's hint/field alongside the message.
+     */
+    actionError?: PresentedJobSubmitError | null;
+    /** Called when the user dismisses the structured error Alert. */
+    onDismissActionError?: () => void;
     /** Whether this is a plant model — affects default media note in dialog */
     isPlantModel?: boolean;
     /** Model reactions for knockout selection */
@@ -40,6 +50,8 @@ export default function ModelDetailHeader({
     onRunGapfill,
     actionLoading,
     actionMessage,
+    actionError,
+    onDismissActionError,
     isPlantModel = false,
     modelReactions = [],
 }: ModelDetailHeaderProps) {
@@ -118,11 +130,17 @@ export default function ModelDetailHeader({
                 </Button>
             </Box>
 
-            {actionMessage && (
+            {actionError ? (
+                <JobSubmitErrorAlert
+                    presented={actionError}
+                    onClose={onDismissActionError}
+                    sx={{ mt: 0, mb: 3 }}
+                />
+            ) : actionMessage ? (
                 <Alert severity="info" sx={{ mb: 3 }}>
                     {actionMessage}
                 </Alert>
-            )}
+            ) : null}
 
             <Divider sx={{ mb: 3 }} />
 

--- a/lib/api/modelseed.ts
+++ b/lib/api/modelseed.ts
@@ -156,10 +156,58 @@ function buildQueryString(params: Record<string, string | undefined>): string {
     return encoded ? `?${encoded}` : '';
 }
 
+/**
+ * Structured error body emitted by modelseed-api pre-flight validation on
+ * job-submit routes (`POST /api/jobs/{reconstruct,gapfill,fba,merge}`).
+ *
+ * FastAPI wraps this object in `{ detail: { ... } }`. See
+ * docs/JOB_ERROR_UI_INTEGRATION.md in the modelseed-api repo.
+ *
+ * `code` is a stable SCREAMING_SNAKE_CASE identifier; treat as an open
+ * enum (new codes may appear without a UI update).
+ */
+export interface ModelseedApiErrorDetail {
+    code: string;
+    message: string;
+    hint?: string | null;
+    field?: string | null;
+    retryable?: boolean;
+}
+
+/**
+ * Thrown by `modelseedFetch` on non-2xx responses. Carries the HTTP status
+ * and (when present) the structured `detail` body so callers can render
+ * `message` + `hint`, highlight the `field` input, or branch on `code`
+ * (e.g. redirect to login on `TOKEN_EXPIRED`).
+ */
+export class ModelseedApiError extends Error {
+    readonly status: number;
+    readonly detail?: ModelseedApiErrorDetail;
+    readonly rawText: string;
+    readonly path: string;
+
+    constructor(
+        status: number,
+        message: string,
+        opts: { detail?: ModelseedApiErrorDetail; rawText?: string; path?: string } = {},
+    ) {
+        super(message);
+        this.name = 'ModelseedApiError';
+        this.status = status;
+        this.detail = opts.detail;
+        this.rawText = opts.rawText ?? '';
+        this.path = opts.path ?? '';
+    }
+}
+
 function extractApiErrorMessage(payload: unknown): string | null {
     if (!payload || typeof payload !== 'object') return null;
     const rec = payload as Record<string, unknown>;
     if (typeof rec.detail === 'string' && rec.detail) return rec.detail;
+    if (rec.detail && typeof rec.detail === 'object') {
+        const det = rec.detail as Record<string, unknown>;
+        if (typeof det.message === 'string' && det.message) return det.message;
+    }
     if (typeof rec.message === 'string' && rec.message) return rec.message;
     const err = rec.error;
     if (err && typeof err === 'object') {
@@ -168,6 +216,31 @@ function extractApiErrorMessage(payload: unknown): string | null {
         if (typeof rpcErr.error === 'string' && rpcErr.error) return rpcErr.error;
     }
     return null;
+}
+
+/**
+ * Pull the structured pre-flight error body out of a FastAPI response.
+ *
+ * Returns null when the body isn't shaped like
+ * `{ detail: { code, message, ... } }` — falls back on string parsing
+ * via `extractApiErrorMessage` so legacy plain-string `detail` responses
+ * still render their text.
+ */
+function extractApiErrorDetail(payload: unknown): ModelseedApiErrorDetail | null {
+    if (!payload || typeof payload !== 'object') return null;
+    const rec = payload as Record<string, unknown>;
+    const det = rec.detail;
+    if (!det || typeof det !== 'object' || Array.isArray(det)) return null;
+    const obj = det as Record<string, unknown>;
+    if (typeof obj.code !== 'string' || !obj.code) return null;
+    if (typeof obj.message !== 'string' || !obj.message) return null;
+    return {
+        code: obj.code,
+        message: obj.message,
+        hint: typeof obj.hint === 'string' ? obj.hint : null,
+        field: typeof obj.field === 'string' ? obj.field : null,
+        retryable: typeof obj.retryable === 'boolean' ? obj.retryable : undefined,
+    };
 }
 
 async function parseJsonResponse(response: Response): Promise<{ payload: unknown; rawText: string }> {
@@ -199,9 +272,12 @@ async function modelseedFetch<T>(path: string, init: RequestInit = {}, requireAu
     const { payload, rawText } = await parseJsonResponse(response);
 
     if (!response.ok) {
-        const detail = extractApiErrorMessage(payload);
-        throw new Error(
-            `modelseed-api ${path} failed (${response.status})${detail ? `: ${detail}` : rawText ? `: ${rawText}` : ''}`,
+        const detail = extractApiErrorDetail(payload);
+        const detailMessage = detail?.message ?? extractApiErrorMessage(payload);
+        throw new ModelseedApiError(
+            response.status,
+            `modelseed-api ${path} failed (${response.status})${detailMessage ? `: ${detailMessage}` : rawText ? `: ${rawText}` : ''}`,
+            { detail: detail ?? undefined, rawText, path },
         );
     }
 

--- a/lib/hooks/useTokenExpiredRedirect.ts
+++ b/lib/hooks/useTokenExpiredRedirect.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import { useCallback } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+
+import { useAuth } from '@/components/auth/AuthProvider';
+import type { PresentedJobSubmitError } from '@/lib/utils/jobErrors';
+
+/**
+ * Returns a handler that, given a presented job-submit error, performs the
+ * `TOKEN_EXPIRED` side-effects (clear stored auth + bounce to the sign-in
+ * page) and tells the caller whether it did so.
+ *
+ * Usage:
+ * ```ts
+ * const maybeRedirect = useTokenExpiredRedirect();
+ * try {
+ *   await submitFooJobFromApi(payload);
+ * } catch (err) {
+ *   const presented = presentJobSubmitError(err);
+ *   if (maybeRedirect(presented)) return; // already navigating
+ *   setError(presented);
+ * }
+ * ```
+ *
+ * Returns true when the redirect was triggered, so the caller can early-exit
+ * without further state churn.
+ */
+export function useTokenExpiredRedirect(): (presented: PresentedJobSubmitError) => boolean {
+    const { logout } = useAuth();
+    const router = useRouter();
+    const pathname = usePathname();
+
+    return useCallback(
+        (presented: PresentedJobSubmitError) => {
+            if (!presented.isTokenExpired) return false;
+            logout();
+            const search = pathname ? `?returnTo=${encodeURIComponent(pathname)}&reason=token_expired` : '?reason=token_expired';
+            void router.replace(`/${search}`);
+            return true;
+        },
+        [logout, router, pathname],
+    );
+}

--- a/lib/utils/jobErrors.ts
+++ b/lib/utils/jobErrors.ts
@@ -1,3 +1,5 @@
+import { ModelseedApiError, type ModelseedApiErrorDetail } from '@/lib/api/modelseed';
+
 /**
  * Humanize Celery/Workspace error messages surfaced by the modelseed_api backend
  * so users see actionable wording instead of raw exception text.
@@ -29,4 +31,89 @@ export function formatJobError(raw: unknown, modelRef?: string): string | undefi
     }
 
     return text;
+}
+
+/**
+ * Decision summary returned by `presentJobSubmitError`. Lets call sites
+ * decide what to render and whether to side-effect (logout/redirect)
+ * without re-implementing detail parsing each time.
+ */
+export interface PresentedJobSubmitError {
+    /** Stable backend code (e.g. `GENOME_NOT_FOUND`), or undefined for unstructured errors. */
+    code?: string;
+    /** Headline one-liner. Always populated. */
+    message: string;
+    /** "What to do next" guidance. Render lighter, under the message. */
+    hint?: string;
+    /** Request-body field name (e.g. `genome`) to highlight in the form. */
+    field?: string;
+    /** True for transient upstream failures; false when the user must change input. */
+    retryable?: boolean;
+    /** HTTP status, when available (sync 4xx path). */
+    status?: number;
+    /** Convenience flag for the auth-expired redirect path. */
+    isTokenExpired: boolean;
+    /**
+     * Single human-readable string suitable for legacy `<Alert>{message}</Alert>`
+     * call sites that haven't been refactored to render hint/field separately.
+     */
+    display: string;
+}
+
+const TOKEN_EXPIRED_CODE = 'TOKEN_EXPIRED';
+
+function getApiErrorDetail(err: unknown): ModelseedApiErrorDetail | undefined {
+    if (err instanceof ModelseedApiError) {
+        return err.detail;
+    }
+    return undefined;
+}
+
+/**
+ * Translate a job-submit exception into a render decision.
+ *
+ * Handles three cases:
+ *  - `ModelseedApiError` with a structured `detail` body → uses backend fields.
+ *  - `ModelseedApiError` without a structured body (5xx, plain-text 4xx) →
+ *    falls back on the message + status.
+ *  - Plain `Error` (network failure, validation thrown before submit) →
+ *    falls back on `.message` (run through `formatJobError` for the
+ *    legacy `_ERROR_Object not found!_ERROR_` substitution).
+ *
+ * @param err - Whatever was caught at the call site
+ * @param opts.modelRef - Workspace ref of the targeted model, used to
+ *   humanize legacy "Object not found" strings.
+ */
+export function presentJobSubmitError(
+    err: unknown,
+    opts: { modelRef?: string } = {},
+): PresentedJobSubmitError {
+    const detail = getApiErrorDetail(err);
+    const status = err instanceof ModelseedApiError ? err.status : undefined;
+
+    if (detail) {
+        const isTokenExpired = detail.code === TOKEN_EXPIRED_CODE;
+        const display = detail.hint ? `${detail.message}\n${detail.hint}` : detail.message;
+        return {
+            code: detail.code,
+            message: detail.message,
+            hint: detail.hint ?? undefined,
+            field: detail.field ?? undefined,
+            retryable: detail.retryable,
+            status,
+            isTokenExpired,
+            display,
+        };
+    }
+
+    const rawMessage = err instanceof Error
+        ? err.message
+        : (typeof err === 'string' ? err : 'Job submission failed.');
+    const humanized = formatJobError(rawMessage, opts.modelRef) ?? rawMessage;
+    return {
+        message: humanized,
+        status,
+        isTokenExpired: status === 401,
+        display: humanized,
+    };
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,12 @@ import * as dotenv from 'dotenv';
 // Read from default ".env" or ".env.local" file
 dotenv.config({ path: '.env.local' });
 
+// Allow tests to target an already-running dev server on a non-default port
+// (e.g. when port 3000 is occupied by another process). Set PLAYWRIGHT_PORT
+// or PLAYWRIGHT_BASE_URL to override the defaults.
+const port = Number(process.env.PLAYWRIGHT_PORT ?? 3000);
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://localhost:${port}`;
+
 
 export default defineConfig({
   testDir: './tests/e2e',
@@ -13,19 +19,19 @@ export default defineConfig({
   workers: 1,
   reporter: [['list'], ['html']],
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL,
     trace: 'retain-on-failure',
     headless: true,
   },
   projects: [
     {
       name: 'chromium-local',
-      use: { ...devices['Desktop Chrome'], baseURL: 'http://localhost:3000', headless: true },
+      use: { ...devices['Desktop Chrome'], baseURL, headless: true },
     },
   ],
   webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:3000',
+    command: `npm run dev -- --port ${port}`,
+    url: baseURL,
     reuseExistingServer: true,
     timeout: 120000,
   },

--- a/tests/e2e/jobs/job-error-integration.spec.ts
+++ b/tests/e2e/jobs/job-error-integration.spec.ts
@@ -1,0 +1,186 @@
+/**
+ * End-to-end coverage for the modelseed-api job-error integration paths
+ * documented in modelseed-api/docs/JOB_ERROR_UI_INTEGRATION.md.
+ *
+ * Path 1 — sync 4xx on submit: pre-flight validation returns a structured
+ *   { detail: { code, message, hint, field, retryable } } body that the UI
+ *   should render as message + hint, with the affected input named.
+ *
+ * Path 2 — async job.error: /api/jobs polling returns `status: "failed"`
+ *   with a stringy `error` field that the UI should surface as a tooltip on
+ *   the Failed badge AND as a click-to-open detail dialog with parameters
+ *   and progress.
+ *
+ * The tests stub the backend via `page.route`, so they run without real
+ * PATRIC credentials. The dev server must be reachable (set
+ * PLAYWRIGHT_BASE_URL or PLAYWRIGHT_PORT if not on the default :3000).
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+
+const STUB_TOKEN = 'stub-patric-token-for-routing-tests';
+
+async function injectStubAuth(page: Page) {
+    await page.goto('/');
+    await page.evaluate((token) => {
+        localStorage.setItem('auth', JSON.stringify({
+            token,
+            user_id: 'stubuser@patricbrc.org',
+            method: 'PATRIC',
+        }));
+    }, STUB_TOKEN);
+}
+
+test.describe('Path 2: /my-jobs renders job.error from failed rows', () => {
+    test.beforeEach(async ({ page }) => {
+        // Stub the /api/jobs polling endpoint with a single failed job so the
+        // grid always has a row to interact with regardless of auth state.
+        await page.route('**/api/jobs**', async (route) => {
+            const url = new URL(route.request().url());
+            if (!url.pathname.endsWith('/api/jobs')) {
+                return route.fallback();
+            }
+            await route.fulfill({
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    'job-failed-token-expiry': {
+                        id: 'job-failed-token-expiry',
+                        app: 'GapfillModel',
+                        status: 'failed',
+                        progress: 'Saving model...',
+                        error: 'WorkspaceError: Token validation failed: Token expired',
+                        parameters: {
+                            command: 'GapfillModel',
+                            arguments: {
+                                model: '/stubuser@patricbrc.org/modelseed/EcoliModel',
+                                media: 'Complete',
+                                template_type: 'gn',
+                                output_path: '/stubuser@patricbrc.org/modelseed/EcoliModel',
+                            },
+                        },
+                        submitTimestamp: new Date(Date.now() - 60_000).toISOString(),
+                        startTimestamp: new Date(Date.now() - 50_000).toISOString(),
+                    },
+                }),
+            });
+        });
+
+        await injectStubAuth(page);
+        await page.goto('/my-jobs');
+        // Auth-gated; if the AuthGuard couldn't hydrate, skip.
+        const guardRedirected = await page
+            .waitForURL('**/', { timeout: 3000 })
+            .then(() => true)
+            .catch(() => false);
+        test.skip(guardRedirected, 'AuthGuard redirected to home — stub auth is not enough.');
+        await page.waitForSelector('[role="grid"]', { timeout: 30_000 });
+    });
+
+    test('shows the error preview as a tooltip on the Failed chip', async ({ page }) => {
+        const failedChip = page.locator('[data-failed-job-chip="true"]');
+        await expect(failedChip).toBeVisible();
+        await failedChip.hover();
+        const tooltip = page.locator('[role="tooltip"]', {
+            hasText: 'Token validation failed: Token expired',
+        });
+        await expect(tooltip).toBeVisible({ timeout: 5000 });
+    });
+
+    test('opens the detail dialog when the failed badge is clicked', async ({ page }) => {
+        const failedChip = page.locator('[data-failed-job-chip="true"]');
+        await failedChip.click();
+
+        const dialog = page.getByTestId('failed-job-details-dialog');
+        await expect(dialog).toBeVisible();
+
+        const errorBlock = page.getByTestId('failed-job-error-text');
+        await expect(errorBlock).toContainText('Token validation failed: Token expired');
+
+        // Progress note from the stubbed job is surfaced verbatim.
+        await expect(dialog).toContainText('Saving model...');
+
+        // Parameters block contains the model arg.
+        await expect(dialog).toContainText('EcoliModel');
+
+        await dialog.getByRole('button', { name: 'Close' }).click();
+        await expect(dialog).toBeHidden();
+    });
+
+    test('opens the detail dialog from the info icon action button', async ({ page }) => {
+        const infoIcon = page.getByTestId('open-failed-job-job-failed-token-expiry');
+        await expect(infoIcon).toBeVisible();
+        await infoIcon.click();
+        await expect(page.getByTestId('failed-job-details-dialog')).toBeVisible();
+    });
+});
+
+test.describe('Path 1: sync 4xx detail surfaces structured error', () => {
+    test('reconstruct submit renders backend message + hint + field when API returns GENOME_NOT_FOUND', async ({ page }) => {
+        // Intercept the FastAPI reconstruct endpoint and return a structured
+        // 404 matching the doc's GENOME_NOT_FOUND example.
+        await page.route('**/api/jobs/reconstruct**', async (route) => {
+            if (route.request().method() !== 'POST') return route.fallback();
+            await route.fulfill({
+                status: 404,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    detail: {
+                        code: 'GENOME_NOT_FOUND',
+                        message: "Genome '9999999.9' could not be fetched from BV-BRC.",
+                        hint: "Check the genome ID is correct (BV-BRC format, e.g. '83332.12').",
+                        field: 'genome',
+                        retryable: false,
+                    },
+                }),
+            });
+        });
+
+        await injectStubAuth(page);
+        await page.goto('/plant');
+
+        // AuthGuard may bounce to home if our stub auth isn't accepted; skip then.
+        const guardRedirected = await page
+            .waitForURL('**/', { timeout: 3000 })
+            .then(() => true)
+            .catch(() => false);
+        test.skip(guardRedirected, 'AuthGuard redirected to home — stub auth is not enough.');
+
+        // Tab 1 is the microbe upload tab (PlantSEED tab 0 is in maintenance).
+        // The submit handler runs `handleUploadSubmit` which requires a file +
+        // a model name. Synthesize a tiny FASTA file in-memory.
+        const fastaContent = '>contig1\nATGCATGCATGCATGCATGCATGC\n';
+        await page.locator('input[type="file"]').setInputFiles({
+            name: 'tiny.fa',
+            mimeType: 'text/plain',
+            buffer: Buffer.from(fastaContent, 'utf8'),
+        });
+
+        await page.getByLabel('Name Model to build', { exact: false }).fill('TestModel');
+
+        await page.getByRole('button', { name: 'Build Model' }).click();
+
+        // The Alert exposes data-error-code for stable selection regardless of
+        // which severity it ends up rendering with.
+        const errorAlert = page.locator('[data-error-code="GENOME_NOT_FOUND"]');
+        await expect(errorAlert).toBeVisible({ timeout: 10_000 });
+        await expect(errorAlert).toContainText("Genome '9999999.9' could not be fetched");
+        await expect(errorAlert).toContainText('Check the genome ID is correct');
+        await expect(errorAlert).toContainText('Affected input:');
+        await expect(errorAlert).toContainText('genome');
+    });
+});
+
+test.describe('Home-page session-expired notice', () => {
+    test('shows the session-expired alert when redirected with ?reason=token_expired', async ({ page }) => {
+        await page.goto('/?reason=token_expired');
+        const notice = page.getByTestId('session-expired-notice');
+        await expect(notice).toBeVisible();
+        await expect(notice).toContainText('Session expired');
+    });
+
+    test('hides the session-expired alert without the query param', async ({ page }) => {
+        await page.goto('/');
+        await expect(page.getByTestId('session-expired-notice')).toHaveCount(0);
+    });
+});

--- a/tests/unit/api/modelseed-job-errors.test.ts
+++ b/tests/unit/api/modelseed-job-errors.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+function setAuthToken(): void {
+    localStorage.setItem('auth', JSON.stringify({
+        user_id: 'testuser',
+        method: 'PATRIC',
+        token: 'test-token',
+    }));
+}
+
+describe('modelseed-api job-submit error parsing (path 1)', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        vi.resetModules();
+        vi.stubEnv('NEXT_PUBLIC_USE_MODELSEED_API', 'true');
+        vi.stubEnv('NEXT_PUBLIC_API_BASE_URL', 'http://localhost:8000');
+        localStorage.clear();
+        setAuthToken();
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it('throws ModelseedApiError with structured detail on FastAPI 404', async () => {
+        const errorBody = {
+            detail: {
+                code: 'GENOME_NOT_FOUND',
+                message: "Genome '9999999.9' could not be fetched from BV-BRC.",
+                hint: "Check the genome ID is correct (BV-BRC format, e.g. '83332.12').",
+                field: 'genome',
+                retryable: false,
+            },
+        };
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            new Response(JSON.stringify(errorBody), {
+                status: 404,
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        );
+
+        const api = await import('@/lib/api/modelseed');
+        await expect(
+            api.submitReconstructJobFromApi({ genome: '9999999.9', template_type: 'gn' }),
+        ).rejects.toBeInstanceOf(api.ModelseedApiError);
+
+        // Re-issue to capture the error instance and inspect its detail.
+        vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+            new Response(JSON.stringify(errorBody), {
+                status: 404,
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        );
+        try {
+            await api.submitReconstructJobFromApi({ genome: '9999999.9' });
+            throw new Error('expected throw');
+        } catch (err) {
+            const e = err as InstanceType<typeof api.ModelseedApiError>;
+            expect(e.status).toBe(404);
+            expect(e.detail?.code).toBe('GENOME_NOT_FOUND');
+            expect(e.detail?.field).toBe('genome');
+            expect(e.detail?.retryable).toBe(false);
+            // Message should embed the human description for legacy callers.
+            expect(e.message).toContain('Genome');
+            expect(e.message).toContain('(404)');
+        }
+    });
+
+    it('falls back gracefully when 4xx body has no structured detail', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            new Response(JSON.stringify({ detail: 'plain string error' }), {
+                status: 422,
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        );
+
+        const api = await import('@/lib/api/modelseed');
+        try {
+            await api.submitGapfillJobFromApi({ model: '/x', media: 'Complete', template_type: 'gn' });
+            throw new Error('expected throw');
+        } catch (err) {
+            const e = err as InstanceType<typeof api.ModelseedApiError>;
+            expect(e.status).toBe(422);
+            expect(e.detail).toBeUndefined();
+            expect(e.message).toContain('plain string error');
+        }
+    });
+
+    it('preserves status when body is empty (e.g. 5xx with no body)', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            new Response('', { status: 502 }),
+        );
+
+        const api = await import('@/lib/api/modelseed');
+        try {
+            await api.submitFbaJobFromApi({ model: '/x', media: 'Complete' });
+            throw new Error('expected throw');
+        } catch (err) {
+            const e = err as InstanceType<typeof api.ModelseedApiError>;
+            expect(e.status).toBe(502);
+            expect(e.detail).toBeUndefined();
+        }
+    });
+
+    it('exposes TOKEN_EXPIRED via detail.code on a 401', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    detail: {
+                        code: 'TOKEN_EXPIRED',
+                        message: 'Your PATRIC token has expired.',
+                        hint: 'Sign in again to continue.',
+                        field: null,
+                        retryable: false,
+                    },
+                }),
+                { status: 401, headers: { 'Content-Type': 'application/json' } },
+            ),
+        );
+
+        const api = await import('@/lib/api/modelseed');
+        try {
+            await api.submitMergeJobFromApi({ models: [], output_file: 'x', output_path: '/x' });
+            throw new Error('expected throw');
+        } catch (err) {
+            const e = err as InstanceType<typeof api.ModelseedApiError>;
+            expect(e.status).toBe(401);
+            expect(e.detail?.code).toBe('TOKEN_EXPIRED');
+        }
+    });
+});

--- a/tests/unit/utils/jobErrors.test.ts
+++ b/tests/unit/utils/jobErrors.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { formatJobError } from '@/lib/utils/jobErrors';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { formatJobError, presentJobSubmitError } from '@/lib/utils/jobErrors';
+import { ModelseedApiError } from '@/lib/api/modelseed';
 
 describe('formatJobError', () => {
     it('returns undefined for empty inputs', () => {
@@ -54,5 +55,84 @@ describe('formatJobError', () => {
         const err = new Error("WorkspaceError('_ERROR_Object not found!_ERROR_')");
         const out = formatJobError(err);
         expect(out).toContain('No model found');
+    });
+});
+
+describe('presentJobSubmitError', () => {
+    beforeEach(() => {
+        vi.stubEnv('NEXT_PUBLIC_USE_MODELSEED_API', 'true');
+        vi.stubEnv('NEXT_PUBLIC_API_BASE_URL', 'http://localhost:8000');
+    });
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it('lifts structured backend detail onto the presented error', () => {
+        const err = new ModelseedApiError(
+            404,
+            'modelseed-api /api/jobs/reconstruct failed (404): Genome not found',
+            {
+                detail: {
+                    code: 'GENOME_NOT_FOUND',
+                    message: 'Genome "9999999.9" could not be fetched from BV-BRC.',
+                    hint: 'Check the genome ID is correct (BV-BRC format).',
+                    field: 'genome',
+                    retryable: false,
+                },
+            },
+        );
+        const out = presentJobSubmitError(err);
+        expect(out.code).toBe('GENOME_NOT_FOUND');
+        expect(out.message).toBe('Genome "9999999.9" could not be fetched from BV-BRC.');
+        expect(out.hint).toBe('Check the genome ID is correct (BV-BRC format).');
+        expect(out.field).toBe('genome');
+        expect(out.retryable).toBe(false);
+        expect(out.status).toBe(404);
+        expect(out.isTokenExpired).toBe(false);
+        expect(out.display).toContain('Genome');
+        expect(out.display).toContain('Check the genome ID');
+    });
+
+    it('flags TOKEN_EXPIRED for the auth redirect path', () => {
+        const err = new ModelseedApiError(401, 'failed (401)', {
+            detail: {
+                code: 'TOKEN_EXPIRED',
+                message: 'Your PATRIC token has expired.',
+                hint: 'Sign in again to continue.',
+                field: null,
+                retryable: false,
+            },
+        });
+        expect(presentJobSubmitError(err).isTokenExpired).toBe(true);
+    });
+
+    it('treats a raw 401 with no structured body as expired (defensive)', () => {
+        const err = new ModelseedApiError(401, 'failed (401)');
+        const out = presentJobSubmitError(err);
+        expect(out.isTokenExpired).toBe(true);
+        expect(out.code).toBeUndefined();
+    });
+
+    it('falls back on plain Error.message when no detail is available', () => {
+        const out = presentJobSubmitError(new Error('Network unreachable'));
+        expect(out.message).toBe('Network unreachable');
+        expect(out.code).toBeUndefined();
+        expect(out.isTokenExpired).toBe(false);
+        expect(out.display).toBe('Network unreachable');
+    });
+
+    it('humanizes legacy _ERROR_Object not found_ERROR_ via modelRef', () => {
+        const out = presentJobSubmitError(
+            new Error('_ERROR_Object not found!_ERROR_'),
+            { modelRef: '/foo/bar/baz' },
+        );
+        expect(out.message).toContain('No model found');
+        expect(out.message).toContain('/foo/bar/baz');
+    });
+
+    it('accepts plain strings safely', () => {
+        const out = presentJobSubmitError('Something exploded');
+        expect(out.message).toBe('Something exploded');
+        expect(out.display).toBe('Something exploded');
     });
 });


### PR DESCRIPTION
## Summary

Implements both rendering paths from [modelseed-api/docs/JOB_ERROR_UI_INTEGRATION.md](https://github.com/ModelSEED/modelseed-api/blob/main/docs/JOB_ERROR_UI_INTEGRATION.md) so users see actionable failures instead of a bare "Failed" badge or a `modelseed-api ... failed (404)` stub.

### Path 1 — sync 4xx on submit (new backend behavior, live 2026-06-10)

- `lib/api/modelseed.ts` introduces `ModelseedApiError` carrying `{ status, detail }` and `extractApiErrorDetail()`. `modelseedFetch` now throws the typed error instead of a flat `Error`, preserving the structured `{ code, message, hint, field, retryable }` body.
- `lib/utils/jobErrors.ts` adds `presentJobSubmitError()` which lifts structured fields onto a render-ready shape and flags `TOKEN_EXPIRED` (also defensively flags any bare 401).
- `components/ui/JobSubmitErrorAlert.tsx` (new) renders the message as the Alert title, `hint` in lighter weight beneath, and an `Affected input: <field>` caption.
- `lib/hooks/useTokenExpiredRedirect.ts` (new) clears auth and redirects to `/?returnTo=…&reason=token_expired`. The home page shows a one-time "Session expired" notice above the sign-in form when the reason is present.
- Three submit call sites are wired through this flow: reconstruct (`app/(build-model)/plant/page.tsx`), FBA/Gapfill (`app/model/[...path]/page.tsx` via a new `actionError` prop on `ModelDetailHeader`), and merge (`app/(user-data)/my-models/page.tsx`).
- Unknown `code` values still render `message` + `hint` (open enum, no hard failure).

### Path 2 — async `job.error` on `/my-jobs` (pre-existing backend behavior)

- The Failed chip itself is now clickable with a tooltip preview of the error string. The existing info-icon action button still works as an alternate entry point.
- New `components/ui/FailedJobDetailsDialog.tsx` renders the full `job.error` (scrollable, monospace), the last `job.progress` note, the `parameters.arguments` block as pretty JSON, and a deep link to the `output_path` model when one is recorded.
- `mergeApiAndTrackedJobs` now plumbs `progress` and `parameters` onto the row so the dialog has the data without a second fetch.

### Test coverage

- 11 new unit tests: `ModelseedApiError` parsing from 404/422/401/empty bodies; `presentJobSubmitError` for structured, unstructured, legacy `_ERROR_Object not found_ERROR_`, and `TOKEN_EXPIRED` cases.
- 6 new Playwright e2e tests: sync 4xx alert renders `GENOME_NOT_FOUND` with message + hint + field, Failed chip tooltip, Failed chip click → dialog, info-icon click → dialog, session-expired notice shown/hidden based on `?reason=token_expired`. Backend calls are stubbed via `page.route`, so no live PATRIC token is required.
- `playwright.config.ts` now respects `PLAYWRIGHT_PORT` / `PLAYWRIGHT_BASE_URL` so tests can run against a dev server bound to a non-default port.

All 108 unit tests pass; the 6 new e2e tests pass on a local dev server. The other pre-existing e2e failures are unrelated (they need a real `PATRIC_TOKEN` to populate the model grid) and reproduce on `staging` without these changes.

## Test plan

- [x] `npm run test:run` — 108/108 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint --quiet .` — clean
- [x] `PLAYWRIGHT_PORT=3005 PLAYWRIGHT_BASE_URL=http://localhost:3005 npx playwright test tests/e2e/jobs/job-error-integration.spec.ts` — 6/6 pass
- [ ] Once merged to staging, exercise on the live deploy with the doc's `curl` recipes (bad genome → see `GENOME_NOT_FOUND` alert; expired token → see session-expired notice on bounce-back)

🤖 Generated with [Claude Code](https://claude.com/claude-code)