### PR TITLE
fix(auth): use token un= verbatim for workspace owner paths (@bvbrc/@patricbrc suffixes)

### DIFF
--- a/app/fba/[...path]/page.tsx
+++ b/app/fba/[...path]/page.tsx
@@ -28,6 +28,7 @@ import CloseIcon from '@mui/icons-material/Close';
 
 import { getModelFbaDataFromApi, getModelFbaFromApi } from '@/lib/api/modelseed';
 import { useAuth } from '@/components/auth/AuthProvider';
+import { expandOwnerRef } from '@/lib/utils/workspacePaths';
 import { workspaceGet, workspaceLs, workspaceDownloadUrl, parseWorkspaceGetObject } from '@/lib/api/workspace';
 import { USE_MODELSEED_API } from '@/lib/api/config';
 import ChemicalEquation from '@/components/ui/ChemicalEquation';
@@ -127,15 +128,6 @@ function extractModelName(fbaPath: string): string {
 function normalizeWorkspaceRef(value: string): string {
     if (!value) return '';
     return value.startsWith('/') ? value : `/${value}`;
-}
-
-function expandOwnerRef(ref: string, authMethod?: string | null): string {
-    if (authMethod !== 'PATRIC') return ref;
-    const normalized = normalizeWorkspaceRef(ref);
-    if (!normalized) return '';
-    const match = normalized.match(/^\/([^/@]+)\/modelseed\/(.+)$/);
-    if (!match) return normalized;
-    return `/${match[1]}@patricbrc.org/modelseed/${match[2]}`;
 }
 
 function dedupeRefs(refs: string[]): string[] {
@@ -467,7 +459,7 @@ function parseExchangeFluxes(data: Record<string, unknown>): FbaExchangeFlux[] {
  * @returns JSX containing FBA results with reaction flux table
  */
 export default function FbaPage({ params }: { params: Promise<{ path: string[] }> }) {
-    const { method: authMethod } = useAuth();
+    const { user: owner } = useAuth();
     const resolvedParams = use(params);
     const workspacePath = `/${resolvedParams.path.join('/')}`;
     const modelRef = extractModelRef(workspacePath);
@@ -487,11 +479,11 @@ export default function FbaPage({ params }: { params: Promise<{ path: string[] }
         const base = workspacePath.endsWith('/') ? workspacePath.slice(0, -1) : workspacePath;
         const modelBase = modelRef.endsWith('/') ? modelRef.slice(0, -1) : modelRef;
         
-        const expandedWs = expandOwnerRef(base, authMethod);
+        const expandedWs = expandOwnerRef(base, owner);
         const wsBases = [expandedWs];
         if (expandedWs !== base) wsBases.push(base);
 
-        const expandedModel = expandOwnerRef(modelBase, authMethod);
+        const expandedModel = expandOwnerRef(modelBase, owner);
         const modelBases = [expandedModel];
         if (expandedModel !== modelBase) modelBases.push(modelBase);
 
@@ -505,7 +497,7 @@ export default function FbaPage({ params }: { params: Promise<{ path: string[] }
             apiCandidates: dedupeRefs(modelBases),
             workspaceCandidates: dedupeRefs(wsCandidates),
         };
-    }, [workspacePath, modelRef, authMethod]);
+    }, [workspacePath, modelRef, owner]);
 
     const { data: fbaData, isLoading, error } = useQuery({
         queryKey: ['fbaDetail', workspacePath, modelRef],

--- a/app/model/[...path]/page.tsx
+++ b/app/model/[...path]/page.tsx
@@ -43,7 +43,8 @@ import {
     submitFbaJobFromApi,
     submitGapfillJobFromApi,
 } from '@/lib/api/modelseed';
-import { getStoredAuthMethod } from '@/lib/api/requestAuth';
+import { getStoredAuthMethod, getStoredAuthUsername } from '@/lib/api/requestAuth';
+import { expandOwnerRef } from '@/lib/utils/workspacePaths';
 import {
     extractTrackedJobId,
     isTerminalJobStatus,
@@ -780,15 +781,6 @@ function ownerAliasRef(ref: string, authMethod?: string | null): string {
     return `/${match[1]}/${match[2]}`;
 }
 
-function expandOwnerRef(ref: string, authMethod?: string | null): string {
-    if (authMethod !== 'PATRIC') return ref;
-    const normalized = normalizeWorkspaceRef(ref);
-    if (!normalized) return '';
-    const match = normalized.match(/^\/([^/@]+)\/modelseed\/(.+)$/);
-    if (!match) return normalized;
-    return `/${match[1]}@patricbrc.org/modelseed/${match[2]}`;
-}
-
 interface WorkspaceListingEntry {
     ref: string;
     id: string;
@@ -1428,6 +1420,7 @@ function VisualizeDataPanel({
 export default function ModelDetailPage({ params }: { params: Promise<{ path: string[] }> }) {
     const router = useRouter();
     const authMethod = getStoredAuthMethod();
+    const owner = getStoredAuthUsername();
     const resolvedParams = use(params);
     const [loadingTooLong, setLoadingTooLong] = useState(false);
     const urlSegments = useMemo(
@@ -1452,13 +1445,13 @@ export default function ModelDetailPage({ params }: { params: Promise<{ path: st
         ? workspacePath.slice(0, -('/model'.length))
         : workspacePath;
     const modelRootCandidates = useMemo(
-        () => dedupeRefs([modelRootPath, ownerAliasRef(modelRootPath, authMethod), expandOwnerRef(modelRootPath, authMethod)]),
-        [modelRootPath, authMethod],
+        () => dedupeRefs([modelRootPath, ownerAliasRef(modelRootPath, authMethod), expandOwnerRef(modelRootPath, owner)]),
+        [modelRootPath, authMethod, owner],
     );
 
     const { apiCandidates, workspaceCandidates } = useMemo(() => {
         const base = workspacePath.endsWith('/') ? workspacePath.slice(0, -1) : workspacePath;
-        const expanded = expandOwnerRef(base, authMethod);
+        const expanded = expandOwnerRef(base, owner);
         const bases = [expanded];
         if (expanded !== base) bases.push(base);
 
@@ -1473,7 +1466,7 @@ export default function ModelDetailPage({ params }: { params: Promise<{ path: st
             apiCandidates: dedupeRefs(bases),
             workspaceCandidates: dedupeRefs(wsCandidates),
         };
-    }, [workspacePath, authMethod]);
+    }, [workspacePath, owner]);
 
     const { data: apiModel, isLoading: apiLoading } = useQuery({
         queryKey: ['apiModel', workspacePath],
@@ -1542,14 +1535,14 @@ export default function ModelDetailPage({ params }: { params: Promise<{ path: st
         }
         // modelseed-api expects the canonical model ref (without trailing /model).
         const canonical = modelRootPath;
-        const expandedCanonical = expandOwnerRef(canonical, authMethod);
+        const expandedCanonical = expandOwnerRef(canonical, owner);
         const canonicalCandidates = dedupeRefs([
             expandedCanonical,
             canonical,
             ownerAliasRef(canonical, authMethod),
         ]);
         return canonicalCandidates[0] ?? null;
-    }, [workspacePath, modelRootPath, authMethod]);
+    }, [workspacePath, modelRootPath, authMethod, owner]);
 
     const { data: modelFba, error: modelFbaError, refetch: refetchModelFba } = useQuery({
         queryKey: ['modelFba', USE_MODELSEED_API, modelApiRef],

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -94,12 +94,13 @@ export async function loginPatric(
     // PATRIC returns a raw token string on 200
     const token = await response.text();
 
-    // Extract user_id from un=<user> segment
+    // Extract user_id from the un=<user> segment and use it VERBATIM.
+    // PATRIC/BV-BRC encode the fully-qualified workspace owner here
+    // (e.g. `user@patricbrc.org`, `user@bvbrc`). Never strip the realm or
+    // append one — workspace paths must match `un=` exactly, otherwise users
+    // with `@bvbrc`/`@patricbrc.org` suffixes get "Insufficient permissions".
     const userIdMatch = token.match(/un=([^|]+)/);
-    let user_id = userIdMatch ? userIdMatch[1] : username;
-    if (!user_id.includes('@')) {
-        user_id = `${user_id}@patricbrc.org`;
-    }
+    const user_id = userIdMatch ? userIdMatch[1].trim() : username;
 
     return { user_id, token: token.trim(), method: 'PATRIC' };
 }

--- a/lib/api/requestAuth.ts
+++ b/lib/api/requestAuth.ts
@@ -64,46 +64,46 @@ export function withRawTokenAuth(
 }
 
 /**
- * Retrieve the stored username from authentication data.
- * 
- * Extracts user_id from stored auth and ensures PATRIC usernames include
- * the @patricbrc.org suffix required for workspace paths. Returns null
- * in SSR context or if no auth is stored.
- * 
- * @returns Username string with @patricbrc.org suffix for PATRIC auth, or null
- * 
+ * Retrieve the authenticated workspace owner, VERBATIM.
+ *
+ * The owner is read from the token's `un=` field — PATRIC/BV-BRC encode the
+ * fully-qualified owner there (e.g. `user@patricbrc.org`, `user@bvbrc`). It is
+ * returned exactly as stored: never stripped, split on `@`, or re-suffixed with
+ * a realm. This value is what workspace/output paths must use, so that users
+ * with `@bvbrc` / `@patricbrc.org` suffixes resolve to the right workspace
+ * (`/user@bvbrc/...`) instead of being rejected for "Insufficient permissions".
+ *
+ * Falls back to the stored `user_id` (itself derived from `un=` at login) if the
+ * token is unavailable. Returns null in SSR context or when no auth is stored.
+ *
+ * @returns The workspace owner string (verbatim), or null
+ *
  * @example
  * ```typescript
- * const username = getStoredAuthUsername();
- * if (username) {
- *   const userWorkspacePath = `/${username}/models`;
+ * const owner = getStoredAuthUsername(); // e.g. "compchemist726@bvbrc"
+ * if (owner) {
+ *   const outputPath = `/${owner}/modelseed`;
  * }
  * ```
  */
 export function getStoredAuthUsername(): string | null {
     if (typeof window === 'undefined') return null;
+
+    // Most authoritative source: the token's `un=` field, used verbatim.
+    const token = getStoredAuthToken();
+    if (token) {
+        const match = token.match(/un=([^|]+)/);
+        const un = match?.[1]?.trim();
+        if (un) return un;
+    }
+
+    // Fallback: the stored user_id (already the verbatim `un=` from login).
     try {
         const raw = localStorage.getItem(AUTH_STORAGE_KEY);
         if (!raw) return null;
-        const parsed = JSON.parse(raw) as { user_id?: string; method?: string };
-        const userId = parsed?.user_id;
-        if (!userId) return null;
-        // PATRIC usernames need @patricbrc.org suffix for workspace paths
-        if (parsed.method === 'PATRIC' && !userId.includes('@')) {
-            return `${userId}@patricbrc.org`;
-        }
-        return userId;
+        const parsed = JSON.parse(raw) as { user_id?: string };
+        return parsed?.user_id?.trim() || null;
     } catch {
-        // Fallback: extract username from token directly if JSON parse fails
-        const token = getStoredAuthToken();
-        if (!token) return null;
-        const parts = token.split('|');
-        for (const part of parts) {
-            if (part.startsWith('un=')) {
-                const value = part.slice(3).trim();
-                return value ? `${value}@patricbrc.org` : null;
-            }
-        }
         return null;
     }
 }

--- a/lib/utils/workspacePaths.ts
+++ b/lib/utils/workspacePaths.ts
@@ -1,0 +1,59 @@
+// lib/utils/workspacePaths.ts
+/**
+ * Helpers for constructing PATRIC / BV-BRC workspace reference paths.
+ *
+ * The workspace owner segment is sensitive: PATRIC/BV-BRC auth tokens carry the
+ * fully-qualified owner in their `un=` field (e.g. `user@patricbrc.org`,
+ * `user@bvbrc`, `user@patricbrc.org` …). That value must be used verbatim when
+ * building paths — never stripped, split on `@`, or rewritten with a hardcoded
+ * realm. A user whose `un=` is `compchemist726@bvbrc` owns
+ * `/compchemist726@bvbrc/...`; emitting `/compchemist726/...` (stripped) or
+ * `/compchemist726@patricbrc.org/...` (wrong realm) makes the workspace reject
+ * the request with "Insufficient permissions".
+ */
+
+/**
+ * Normalize a workspace ref to a leading-slash absolute path.
+ *
+ * @param value - A workspace ref, with or without a leading slash
+ * @returns The ref guaranteed to start with `/`, or `''` for empty input
+ */
+export function normalizeWorkspaceRef(value: string): string {
+    if (!value) return '';
+    return value.startsWith('/') ? value : `/${value}`;
+}
+
+/**
+ * Apply the authenticated owner's realm to a bare-owner workspace ref.
+ *
+ * Some refs reach the UI with a bare owner segment (`/user/modelseed/Model`) —
+ * e.g. from a typed path or a legacy link. The correct realm is whatever the
+ * logged-in user's token `un=` carries, so we copy the realm suffix from
+ * `owner` (the verbatim `un=` value) rather than guessing `@patricbrc.org`.
+ *
+ * No-ops (returns the normalized ref unchanged) when:
+ *  - there is no owner / the owner has no realm to copy, or
+ *  - the ref already carries a realm, or isn't an owner-rooted modelseed ref.
+ *
+ * @param ref - Workspace ref, possibly with a bare owner segment
+ * @param owner - Authenticated owner from `un=` verbatim (e.g. `user@bvbrc`)
+ * @returns The ref with the owner's realm applied, or unchanged
+ *
+ * @example
+ * expandOwnerRef('/compchemist726/modelseed/Ecoli', 'compchemist726@bvbrc')
+ * // → '/compchemist726@bvbrc/modelseed/Ecoli'
+ */
+export function expandOwnerRef(ref: string, owner?: string | null): string {
+    const normalized = normalizeWorkspaceRef(ref);
+    if (!normalized || !owner) return normalized;
+
+    const at = owner.indexOf('@');
+    if (at <= 0) return normalized; // owner carries no realm to apply
+
+    const realm = owner.slice(at); // includes the leading '@'
+    // Only expand a bare-owner modelseed ref; leave qualified refs intact.
+    const match = normalized.match(/^\/([^/@]+)\/modelseed\/(.+)$/);
+    if (!match) return normalized;
+
+    return `/${match[1]}${realm}/modelseed/${match[2]}`;
+}

--- a/tests/unit/api/auth.test.ts
+++ b/tests/unit/api/auth.test.ts
@@ -55,6 +55,32 @@ describe('auth API', () => {
       expect(result.method).toBe('PATRIC');
       expect(mockFetch).not.toHaveBeenCalled();
     });
+
+    it('uses a fully-qualified un= verbatim (@bvbrc — no strip, no re-suffix)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve('tok|un=compchemist726@bvbrc|tokenid=x|expiry=1'),
+      });
+
+      const { loginPatric } = await import('@/lib/api/auth');
+      const result = await loginPatric('compchemist726', 'pw');
+
+      // Regression: the workspace lives at /compchemist726@bvbrc/... — the
+      // suffix must survive so output paths aren't rejected for permissions.
+      expect(result.user_id).toBe('compchemist726@bvbrc');
+    });
+
+    it('does not append @patricbrc.org to a bare un=', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve('tok|un=plainuser|tokenid=x|expiry=1'),
+      });
+
+      const { loginPatric } = await import('@/lib/api/auth');
+      const result = await loginPatric('plainuser', 'pw');
+
+      expect(result.user_id).toBe('plainuser');
+    });
   });
 
   describe('RAST login flow', () => {

--- a/tests/unit/api/requestAuth.test.ts
+++ b/tests/unit/api/requestAuth.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * getStoredAuthUsername resolves the workspace OWNER used to build output/
+ * workspace paths. It must return the token's un= value VERBATIM — never
+ * stripping the realm (`@bvbrc`) or re-suffixing with `@patricbrc.org`.
+ */
+describe('getStoredAuthUsername — workspace owner (verbatim un=)', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        const store: Record<string, string> = {};
+        vi.stubGlobal('localStorage', {
+            getItem: (k: string) => store[k] ?? null,
+            setItem: (k: string, v: string) => { store[k] = v; },
+            removeItem: (k: string) => { delete store[k]; },
+        });
+    });
+
+    async function setAuthAndRead(auth: Record<string, unknown>) {
+        localStorage.setItem('auth', JSON.stringify(auth));
+        const { getStoredAuthUsername } = await import('@/lib/api/requestAuth');
+        return getStoredAuthUsername();
+    }
+
+    it('returns the @bvbrc owner verbatim from the token un=', async () => {
+        expect(
+            await setAuthAndRead({
+                user_id: 'compchemist726@bvbrc',
+                token: 'tok|un=compchemist726@bvbrc|expiry=1',
+                method: 'PATRIC',
+            }),
+        ).toBe('compchemist726@bvbrc');
+    });
+
+    it('returns an @patricbrc.org owner verbatim', async () => {
+        expect(
+            await setAuthAndRead({
+                user_id: 'alice@patricbrc.org',
+                token: 'tok|un=alice@patricbrc.org|expiry=1',
+                method: 'PATRIC',
+            }),
+        ).toBe('alice@patricbrc.org');
+    });
+
+    it('does not append a realm to a bare un=', async () => {
+        expect(
+            await setAuthAndRead({
+                user_id: 'bob',
+                token: 'tok|un=bob|expiry=1',
+                method: 'PATRIC',
+            }),
+        ).toBe('bob');
+    });
+
+    it('falls back to the stored user_id verbatim when the token has no un=', async () => {
+        expect(
+            await setAuthAndRead({
+                user_id: 'carol@bvbrc',
+                token: 'opaque-token-without-un',
+                method: 'PATRIC',
+            }),
+        ).toBe('carol@bvbrc');
+    });
+
+    it('returns null when nothing is stored', async () => {
+        const { getStoredAuthUsername } = await import('@/lib/api/requestAuth');
+        expect(getStoredAuthUsername()).toBeNull();
+    });
+});

--- a/tests/unit/utils/workspacePaths.test.ts
+++ b/tests/unit/utils/workspacePaths.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { expandOwnerRef, normalizeWorkspaceRef } from '@/lib/utils/workspacePaths';
+
+describe('expandOwnerRef', () => {
+    it('applies the owner @bvbrc realm to a bare-owner ref', () => {
+        expect(expandOwnerRef('/compchemist726/modelseed/Ecoli', 'compchemist726@bvbrc'))
+            .toBe('/compchemist726@bvbrc/modelseed/Ecoli');
+    });
+
+    it('applies an @patricbrc.org realm', () => {
+        expect(expandOwnerRef('/alice/modelseed/M', 'alice@patricbrc.org'))
+            .toBe('/alice@patricbrc.org/modelseed/M');
+    });
+
+    it('leaves an already-qualified ref unchanged', () => {
+        expect(expandOwnerRef('/compchemist726@bvbrc/modelseed/Ecoli', 'compchemist726@bvbrc'))
+            .toBe('/compchemist726@bvbrc/modelseed/Ecoli');
+    });
+
+    it('no-ops when the owner carries no realm', () => {
+        expect(expandOwnerRef('/bob/modelseed/M', 'bob')).toBe('/bob/modelseed/M');
+    });
+
+    it('no-ops without an owner', () => {
+        expect(expandOwnerRef('/bob/modelseed/M', null)).toBe('/bob/modelseed/M');
+        expect(expandOwnerRef('/bob/modelseed/M')).toBe('/bob/modelseed/M');
+    });
+
+    it('normalizes a missing leading slash before expanding', () => {
+        expect(expandOwnerRef('compchemist726/modelseed/M', 'compchemist726@bvbrc'))
+            .toBe('/compchemist726@bvbrc/modelseed/M');
+    });
+
+    it('only rewrites owner-rooted modelseed refs', () => {
+        expect(expandOwnerRef('/some/other/path', 'x@bvbrc')).toBe('/some/other/path');
+    });
+});
+
+describe('normalizeWorkspaceRef', () => {
+    it('adds a leading slash', () => {
+        expect(normalizeWorkspaceRef('a/b')).toBe('/a/b');
+    });
+
+    it('keeps an existing leading slash', () => {
+        expect(normalizeWorkspaceRef('/a/b')).toBe('/a/b');
+    });
+
+    it('returns empty string for empty input', () => {
+        expect(normalizeWorkspaceRef('')).toBe('');
+    });
+});


### PR DESCRIPTION
## Problem

Reported by José: the frontend stripped/rewrote the workspace **owner realm** when building output paths. A user whose token `un=` is `compchemist726@bvbrc` owns `/compchemist726@bvbrc/...`, but jobs were submitted to `/compchemist726/modelseed` (suffix stripped), and elsewhere the realm was hardcoded to `@patricbrc.org`. The PATRIC/BV-BRC workspace then rejected them with **"Insufficient permissions"** — matching the new backend pre-flight `OUTPUT_PATH_NOT_OWNED` (commit `71e124a`).

Users with `@bvbrc` or `@patricbrc.org` suffixes in their token's `un=` field need the **full value used verbatim** — don't strip, split, or re-suffix.

## Fix

Use the auth token's `un=` value as-is everywhere the owner segment is built.

- **`loginPatric`** — store `user_id` = `un=` verbatim (drop the `@patricbrc.org` append).
- **`getStoredAuthUsername`** — return `un=` verbatim (token-first); removes the catch-fallback that double-suffixed already-qualified owners.
- **`lib/utils/workspacePaths.ts`** (new) — shared `expandOwnerRef` derives the realm from the logged-in owner's `un=` instead of hardcoding `@patricbrc.org`, so a bare ref expands to `/<user>@bvbrc/...` for BV-BRC users (and `@patricbrc.org` for PATRIC users, unchanged).
- **`app/model/[...path]`** and **`app/fba/[...path]`** — use the shared helper with the verbatim owner instead of the auth method.

## Tests

+17 unit tests (`loginPatric`, `getStoredAuthUsername`, `expandOwnerRef`) covering `@bvbrc`, `@patricbrc.org`, bare, and fallback cases — these would have caught the regression.

Local verification (CI-equivalent): `lint`, `tsc --noEmit`, `vitest run` (**125 passed**), `next build`, and `npm audit --omit=dev --audit-level=high` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
