### PR TITLE
feat(feedback): add homepage GitHub Issues link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - User feedback FAB and dialog with `/api/feedback` proxy route and unit test
 - GitHub issue templates, pull request template, and CODEOWNERS
+- GitHub Issues link beside Contact us in the homepage support section
 
 ### Fixed
 - Production `npm audit` findings resolved: Next.js upgraded to **16.3.0**,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,6 +14,7 @@ import styles from './home.module.css';
 import { useAuth } from '@/components/auth/AuthProvider';
 import Alert from '@mui/material/Alert';
 import AlertTitle from '@mui/material/AlertTitle';
+import { GITHUB_ISSUES_URL } from '@/components/feedback/feedbackOptions';
 
 type AuthMethod = 'rast' | 'patric';
 
@@ -406,11 +407,23 @@ function HomePageContent() {
                     <Typography variant="h6" sx={{ fontWeight: 600, mt: 3, mb: 1 }}>
                         Questions, comments, and bug reports?
                     </Typography>
-                    <Typography>
-                        <a href="mailto:help@modelseed.org" style={{ color: '#30BCCF', textDecoration: 'none' }}>
-                            Contact us
-                        </a>
-                    </Typography>
+                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+                        <Typography>
+                            <a href="mailto:help@modelseed.org" style={{ color: '#30BCCF', textDecoration: 'none' }}>
+                                Contact us
+                            </a>
+                        </Typography>
+                        <Typography>
+                            <a
+                                href={GITHUB_ISSUES_URL}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                style={{ color: '#30BCCF', textDecoration: 'none' }}
+                            >
+                                GitHub Issues
+                            </a>
+                        </Typography>
+                    </Box>
                 </Container>
             </Box>
         </>

--- a/components/feedback/feedbackOptions.ts
+++ b/components/feedback/feedbackOptions.ts
@@ -25,6 +25,7 @@ export type Environment = (typeof ENVIRONMENTS)[number];
 
 // Maps the dialog "Type" to the GitHub Issue Form template filename + label to prefill.
 export const GITHUB_REPO = 'ModelSEED/ModelSEED-UI';
+export const GITHUB_ISSUES_URL = `https://github.com/${GITHUB_REPO}/issues`;
 export const TEMPLATE_BY_TYPE: Record<FeedbackType, string> = {
   Bug: 'bug_report.yml',
   Feature: 'feature_request.yml',
@@ -72,5 +73,5 @@ export function buildGitHubIssueUrl(input: {
     params.set('environment', ENV_TO_GH_OPTION[input.environment]);
     params.set('question', input.description);
   }
-  return `https://github.com/${GITHUB_REPO}/issues/new?${params.toString()}`;
+  return `${GITHUB_ISSUES_URL}/new?${params.toString()}`;
 }

--- a/tests/e2e/suite.spec.ts
+++ b/tests/e2e/suite.spec.ts
@@ -61,6 +61,20 @@ test.describe('01. Public Pages', () => {
     expect(await links.count()).toBeGreaterThan(5);
   });
 
+  test('Homepage support section has Contact us and GitHub Issues links', async ({ page }) => {
+    await page.goto('/');
+    const contactLink = page.getByRole('link', { name: 'Contact us' });
+    await expect(contactLink).toBeVisible();
+    await expect(contactLink).toHaveAttribute('href', 'mailto:help@modelseed.org');
+
+    const issuesLink = page.getByRole('link', { name: 'GitHub Issues' });
+    await expect(issuesLink).toBeVisible();
+    await expect(issuesLink).toHaveAttribute('href', 'https://github.com/ModelSEED/ModelSEED-UI/issues');
+    await expect(issuesLink).toHaveAttribute('target', '_blank');
+    await expect(issuesLink).toHaveAttribute('rel', /noopener/);
+    await expect(issuesLink).toHaveAttribute('rel', /noreferrer/);
+  });
+
   const publicPages = [
     { path: '/about', name: 'About' },
     { path: '/about/version', name: 'Version' },


### PR DESCRIPTION
## Summary
- add an accessible GitHub Issues link beside Contact us in the homepage support section
- reuse the shared ModelSEED-UI issues URL for the feedback dialog and homepage
- cover the link and its safe external-link attributes in the homepage E2E suite
- retain the change under the pending 3.1.0 changelog entry

## Verification
- `npm run lint` (0 errors; 16 pre-existing warnings)
- `npx tsc --noEmit`
- `npm run test:run` (125 passed)
- `npm run build`
- `npm audit --omit=dev --audit-level=high` (0 vulnerabilities)

## E2E note
The focused Playwright test could not run locally because the sandbox lacks the Chromium browser binary. A local dev-server HTML check confirmed the exact rendered href, target, and rel attributes; upstream CI will exercise the workflow.