### PR TITLE
fix(model-export): make model TSV download work (#221)

### DIFF
--- a/app/model/[...path]/page.tsx
+++ b/app/model/[...path]/page.tsx
@@ -2227,7 +2227,7 @@ export default function ModelDetailPage({ params }: { params: Promise<{ path: st
                         modelRef={workspaceCandidates[0]}
                         modelId={modelName}
                         buttonLabel="Download options"
-                        helperText="Export this model as SBML, JSON, or TSV."
+                        helperText="Export this model as SBML or JSON, or download the reaction and compound tables as TSV."
                     />
                     {isPlantModel && (
                         <Button

--- a/components/ui/DownloadModelMenu.tsx
+++ b/components/ui/DownloadModelMenu.tsx
@@ -7,6 +7,7 @@ import MenuItem from '@mui/material/MenuItem';
 import CircularProgress from '@mui/material/CircularProgress';
 import Typography from '@mui/material/Typography';
 import { exportModelFromApi } from '@/lib/api/modelseed';
+import { buildCompoundsTsv, buildReactionsTsv, type ModelExportJson } from '@/lib/utils/modelTsv';
 
 interface DownloadModelMenuProps {
     modelRef: string;
@@ -15,10 +16,15 @@ interface DownloadModelMenuProps {
     helperText?: string;
 }
 
-const EXPORT_OPTIONS = [
-    { label: 'SBML', format: 'sbml', extension: 'xml' },
-    { label: 'JSON', format: 'json', extension: 'json' },
-    { label: 'TSV', format: 'tsv', extension: 'tsv' },
+type ExportOption =
+    | { key: string; label: string; kind: 'api'; format: 'sbml' | 'json'; extension: string }
+    | { key: string; label: string; kind: 'derived-tsv'; table: 'reactions' | 'compounds' };
+
+export const EXPORT_OPTIONS: readonly ExportOption[] = [
+    { key: 'sbml', label: 'SBML', kind: 'api', format: 'sbml', extension: 'xml' },
+    { key: 'json', label: 'JSON', kind: 'api', format: 'json', extension: 'json' },
+    { key: 'reactions-tsv', label: 'Reactions (TSV)', kind: 'derived-tsv', table: 'reactions' },
+    { key: 'compounds-tsv', label: 'Compounds (TSV)', kind: 'derived-tsv', table: 'compounds' },
 ] as const;
 
 function triggerBrowserDownload(blob: Blob, filename: string): void {
@@ -39,7 +45,7 @@ export default function DownloadModelMenu({
     helperText,
 }: DownloadModelMenuProps) {
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-    const [downloadingFormat, setDownloadingFormat] = useState<string | null>(null);
+    const [downloadingKey, setDownloadingKey] = useState<string | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
@@ -52,25 +58,44 @@ export default function DownloadModelMenu({
     };
 
     const handleClose = () => {
-        if (!downloadingFormat) {
+        if (!downloadingKey) {
             setAnchorEl(null);
         }
     };
 
-    const handleDownload = async (format: string, extension: string) => {
+    const handleDownload = async (option: ExportOption) => {
         setError(null);
         setSuccessMessage(null);
-        setDownloadingFormat(format);
+        setDownloadingKey(option.key);
         try {
-            const blob = await exportModelFromApi(modelRef, format);
-            triggerBrowserDownload(blob, `${modelId}.${extension}`);
+            let blob: Blob;
+            let filename: string;
+
+            if (option.kind === 'api') {
+                blob = await exportModelFromApi(modelRef, option.format);
+                filename = `${modelId}.${option.extension}`;
+            } else {
+                const jsonBlob = await exportModelFromApi(modelRef, 'json');
+                const text = await jsonBlob.text();
+                let model: ModelExportJson;
+                try {
+                    model = JSON.parse(text);
+                } catch {
+                    throw new Error('The model export did not return valid JSON, so the TSV table could not be built.');
+                }
+                const tsv = option.table === 'reactions' ? buildReactionsTsv(model) : buildCompoundsTsv(model);
+                blob = new Blob([tsv], { type: 'text/tab-separated-values;charset=utf-8;' });
+                filename = `${modelId}.${option.table}.tsv`;
+            }
+
+            triggerBrowserDownload(blob, filename);
             setAnchorEl(null);
-            setSuccessMessage(`Downloaded ${modelId}.${extension}`);
+            setSuccessMessage(`Downloaded ${filename}`);
         } catch (err) {
             const message = err instanceof Error ? err.message : 'Failed to export model';
             setError(message);
         } finally {
-            setDownloadingFormat(null);
+            setDownloadingKey(null);
         }
     };
 
@@ -93,11 +118,11 @@ export default function DownloadModelMenu({
             >
                 {EXPORT_OPTIONS.map((option) => (
                     <MenuItem
-                        key={option.format}
-                        disabled={Boolean(downloadingFormat)}
-                        onClick={() => handleDownload(option.format, option.extension)}
+                        key={option.key}
+                        disabled={Boolean(downloadingKey)}
+                        onClick={() => handleDownload(option)}
                     >
-                        {downloadingFormat === option.format ? (
+                        {downloadingKey === option.key ? (
                             <>
                                 <CircularProgress size={14} sx={{ mr: 1 }} />
                                 Exporting {option.label}...

--- a/lib/api/modelseed.ts
+++ b/lib/api/modelseed.ts
@@ -469,7 +469,9 @@ export async function getModelDetailBundleFromApi(ref: string): Promise<ModelDet
 
 /**
  * Returns a Blob containing the exported model file.
- * formats: 'sbml' | 'json' | 'tsv'
+ * Backend-supported formats (GET /api/models/export): 'json' | 'sbml' | 'cobrapy'.
+ * TSV is not a backend format; reaction/compound TSV tables are derived client-side
+ * from the 'json' export - see lib/utils/modelTsv.ts.
  */
 export async function exportModelFromApi(ref: string, format: string): Promise<Blob> {
     const response = await fetch(

--- a/lib/utils/modelTsv.ts
+++ b/lib/utils/modelTsv.ts
@@ -1,0 +1,100 @@
+/**
+ * Model TSV Export Utilities
+ *
+ * Derives tab-separated reaction and compound tables from a ModelSEED
+ * `format=json` model export. The ModelSEED backend does not support a
+ * `format=tsv` export (see `/api/models/export` OpenAPI spec: only
+ * `json | sbml | cobrapy` are supported), so these tables are built
+ * client-side from the JSON export instead.
+ */
+
+import { objectsToCsv } from '@/lib/utils/exportCsv';
+
+export interface ModelExportCompound {
+    id?: string | null;
+    name?: string | null;
+    formula?: string | null;
+    charge?: number | null;
+}
+
+export interface ModelExportPathway {
+    source?: string | null;
+    id?: string | null;
+    name?: string | null;
+}
+
+export interface ModelExportReaction {
+    id?: string | null;
+    name?: string | null;
+    direction?: string | null;
+    equation?: string | null;
+    gpr?: string | null;
+    genes?: string[] | null;
+    pathways?: ModelExportPathway[] | null;
+}
+
+export interface ModelExportJson {
+    compounds?: ModelExportCompound[] | null;
+    reactions?: ModelExportReaction[] | null;
+}
+
+/**
+ * Derive the compartment suffix from a ModelSEED id, e.g. "cpd00443_c0" -> "c0".
+ * Returns '' when the id has no compartment suffix or is missing.
+ */
+export function compartmentFromId(id: string | null | undefined): string {
+    if (!id) return '';
+    const match = id.match(/_([a-z]+\d*)$/);
+    return match ? match[1] : '';
+}
+
+function pathwaysToCell(pathways: ModelExportPathway[] | null | undefined): string {
+    if (!pathways || pathways.length === 0) return '';
+    const labels = pathways.map((pathway) => pathway.name || pathway.id || '');
+    const unique = Array.from(new Set(labels.filter((label) => label !== '')));
+    return unique.join('|');
+}
+
+/** Throws Error('This model has no compounds to export.') when compounds is missing/empty. */
+export function buildCompoundsTsv(model: ModelExportJson): string {
+    const compounds = model.compounds;
+    if (!compounds || compounds.length === 0) {
+        throw new Error('This model has no compounds to export.');
+    }
+
+    const rows = compounds.map((compound) => ({
+        id: compound.id,
+        name: compound.name,
+        formula: compound.formula,
+        charge: compound.charge,
+        compartment: compartmentFromId(compound.id),
+    }));
+
+    return objectsToCsv(rows, {
+        columns: ['id', 'name', 'formula', 'charge', 'compartment'],
+        delimiter: '\t',
+    });
+}
+
+/** Throws Error('This model has no reactions to export.') when reactions is missing/empty. */
+export function buildReactionsTsv(model: ModelExportJson): string {
+    const reactions = model.reactions;
+    if (!reactions || reactions.length === 0) {
+        throw new Error('This model has no reactions to export.');
+    }
+
+    const rows = reactions.map((reaction) => ({
+        id: reaction.id,
+        direction: reaction.direction,
+        compartment: compartmentFromId(reaction.id),
+        gpr: reaction.gpr,
+        name: reaction.name,
+        equation: reaction.equation,
+        pathways: pathwaysToCell(reaction.pathways),
+    }));
+
+    return objectsToCsv(rows, {
+        columns: ['id', 'direction', 'compartment', 'gpr', 'name', 'equation', 'pathways'],
+        delimiter: '\t',
+    });
+}

--- a/tests/unit/components/downloadModelMenuOptions.test.ts
+++ b/tests/unit/components/downloadModelMenuOptions.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { EXPORT_OPTIONS } from '@/components/ui/DownloadModelMenu';
+
+// Backend contract, verified live at https://modelseed.org/PMS/openapi.json (2026-08-05):
+// "Export a model in the specified format.  Supported formats: json, sbml, cobrapy."
+const API_SUPPORTED_FORMATS = ['json', 'sbml', 'cobrapy'];
+
+describe('DownloadModelMenu EXPORT_OPTIONS contract', () => {
+    it('never requests a format outside the API-supported set for kind:"api" options', () => {
+        const apiOptions = EXPORT_OPTIONS.filter((option) => option.kind === 'api');
+        expect(apiOptions.length).toBeGreaterThan(0);
+        for (const option of apiOptions) {
+            expect(API_SUPPORTED_FORMATS).toContain(option.format);
+        }
+    });
+
+    it('never requests the unsupported "tsv" format from the API', () => {
+        for (const option of EXPORT_OPTIONS) {
+            if (option.kind === 'api') {
+                expect(option.format).not.toBe('tsv');
+            }
+        }
+    });
+
+    it('has unique option keys', () => {
+        const keys = EXPORT_OPTIONS.map((option) => option.key);
+        expect(new Set(keys).size).toBe(keys.length);
+    });
+
+    it('includes both derived TSV table options', () => {
+        const reactionsTsv = EXPORT_OPTIONS.find((option) => option.key === 'reactions-tsv');
+        const compoundsTsv = EXPORT_OPTIONS.find((option) => option.key === 'compounds-tsv');
+
+        expect(reactionsTsv).toBeDefined();
+        expect(reactionsTsv?.kind).toBe('derived-tsv');
+        expect(compoundsTsv).toBeDefined();
+        expect(compoundsTsv?.kind).toBe('derived-tsv');
+    });
+});

--- a/tests/unit/utils/modelTsv.test.ts
+++ b/tests/unit/utils/modelTsv.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import {
+    compartmentFromId,
+    buildCompoundsTsv,
+    buildReactionsTsv,
+    type ModelExportJson,
+} from '@/lib/utils/modelTsv';
+
+describe('modelTsv', () => {
+    describe('compartmentFromId', () => {
+        it('extracts the compartment suffix from a compound id', () => {
+            expect(compartmentFromId('cpd00443_c0')).toBe('c0');
+        });
+
+        it('extracts the compartment suffix from a reaction id', () => {
+            expect(compartmentFromId('rxn02201_e0')).toBe('e0');
+        });
+
+        it('returns "" when there is no compartment suffix', () => {
+            expect(compartmentFromId('cpd00001')).toBe('');
+        });
+
+        it('returns "" for undefined', () => {
+            expect(compartmentFromId(undefined)).toBe('');
+        });
+
+        it('returns "" for null', () => {
+            expect(compartmentFromId(null)).toBe('');
+        });
+    });
+
+    describe('buildCompoundsTsv', () => {
+        it('has the exact header row', () => {
+            const model: ModelExportJson = {
+                compounds: [{ id: 'cpd00443_c0', name: 'ABEE [c0]', formula: 'C7H6NO2', charge: -1 }],
+            };
+            const [header] = buildCompoundsTsv(model).split('\n');
+            expect(header).toBe('id\tname\tformula\tcharge\tcompartment');
+        });
+
+        it('renders a compound row with the derived compartment', () => {
+            const model: ModelExportJson = {
+                compounds: [{ id: 'cpd00443_c0', name: 'ABEE [c0]', formula: 'C7H6NO2', charge: -1 }],
+            };
+            const [, row] = buildCompoundsTsv(model).split('\n');
+            expect(row).toBe('cpd00443_c0\tABEE [c0]\tC7H6NO2\t-1\tc0');
+        });
+
+        it('renders charge: 0 as "0", not an empty cell', () => {
+            const model: ModelExportJson = {
+                compounds: [{ id: 'cpd00001_c0', name: 'H2O', formula: 'H2O', charge: 0 }],
+            };
+            const [, row] = buildCompoundsTsv(model).split('\n');
+            expect(row.split('\t')[3]).toBe('0');
+        });
+
+        it('throws when compounds is missing', () => {
+            expect(() => buildCompoundsTsv({})).toThrow('This model has no compounds to export.');
+        });
+
+        it('throws when compounds is empty', () => {
+            expect(() => buildCompoundsTsv({ compounds: [] })).toThrow('This model has no compounds to export.');
+        });
+    });
+
+    describe('buildReactionsTsv', () => {
+        it('has the exact header row', () => {
+            const model: ModelExportJson = {
+                reactions: [{ id: 'rxn00001_c0', direction: '>', name: 'Test', equation: 'A => B', gpr: 'gene1' }],
+            };
+            const [header] = buildReactionsTsv(model).split('\n');
+            expect(header).toBe('id\tdirection\tcompartment\tgpr\tname\tequation\tpathways');
+        });
+
+        it('does not quote a reaction name containing a comma (tab delimiter)', () => {
+            const model: ModelExportJson = {
+                reactions: [
+                    {
+                        id: 'rxn00001_c0',
+                        direction: '>',
+                        name: 'Alpha, Beta Synthase',
+                        equation: 'A + B => C',
+                        gpr: 'gene1',
+                    },
+                ],
+            };
+            const [, row] = buildReactionsTsv(model).split('\n');
+            const cells = row.split('\t');
+            expect(cells[4]).toBe('Alpha, Beta Synthase');
+            expect(cells[4]).not.toContain('"');
+        });
+
+        it('joins pathway names with "|", falling back to id when name is empty, de-duplicated', () => {
+            const model: ModelExportJson = {
+                reactions: [
+                    {
+                        id: 'rxn00001_c0',
+                        direction: '>',
+                        pathways: [
+                            { source: 'MetaCyc', id: 'PWY-1', name: 'alpha' },
+                            { source: 'KEGG', id: 'map001', name: '' },
+                        ],
+                    },
+                ],
+            };
+            const [, row] = buildReactionsTsv(model).split('\n');
+            const cells = row.split('\t');
+            expect(cells[6]).toBe('alpha|map001');
+        });
+
+        it('renders empty cells for missing name/gpr/equation, with the full column count', () => {
+            const model: ModelExportJson = {
+                reactions: [{ id: 'rxn00001_c0', direction: '>' }],
+            };
+            const [, row] = buildReactionsTsv(model).split('\n');
+            const cells = row.split('\t');
+            expect(cells).toHaveLength(7);
+            expect(cells[3]).toBe(''); // gpr
+            expect(cells[4]).toBe(''); // name
+            expect(cells[5]).toBe(''); // equation
+            expect(cells[6]).toBe(''); // pathways
+        });
+
+        it('throws when reactions is missing', () => {
+            expect(() => buildReactionsTsv({})).toThrow('This model has no reactions to export.');
+        });
+
+        it('throws when reactions is empty', () => {
+            expect(() => buildReactionsTsv({ reactions: [] })).toThrow('This model has no reactions to export.');
+        });
+    });
+});


### PR DESCRIPTION
Fixes the actionable half of #221.

## What was actually wrong

**TSV download (real bug).** The model Download menu offered a `TSV` entry that issued
`GET /api/models/export?ref=…&format=tsv`. The ModelSEED API only supports `json`, `sbml` and
`cobrapy` — verified live against https://modelseed.org/PMS/openapi.json:

> `Export a model in the specified format.  Supported formats: json, sbml, cobrapy.`

So that menu entry could never produce a file. Nothing in the repo tested it
(`scripts/api-test.mjs` and `scripts/comprehensive-api-test.mjs` only cover SBML and JSON).

**SBML download (not a bug).** The reporter's attached `DC1RawModel.xml` was downloaded and
checked: it is complete, well-formed **SBML L3V1 + FBC v2** — 1100 `<species>`, 1127 `<reaction>`,
unit definitions, compartments, `fbc:objective fbc:type="maximize"`, `fbc:listOfGeneProducts`,
properly closed `</model></sbml>`. The `kbase_compartment_data` / `modelseed_template_id: cpdXXXX_c`
lines they saw are the text of legal `<notes><html><p>…</p></html></notes>` blocks, which is what a
browser shows if it renders the file as HTML. **No SBML change was made or needed** — that file
should load in COBRA Toolbox / cobrapy as-is.

## The fix

Build the tabular exports client-side from the *supported* `format=json` export, and split the one
dead entry into two working ones:

| Menu entry | Source | File |
|---|---|---|
| SBML | API `format=sbml` | `<model>.xml` (unchanged) |
| JSON | API `format=json` | `<model>.json` (unchanged) |
| **Reactions (TSV)** | derived from `format=json` | `<model>.reactions.tsv` |
| **Compounds (TSV)** | derived from `format=json` | `<model>.compounds.tsv` |

Columns follow the legacy `rxntbl`/`cpdtbl` shape the issue asks for:

- reactions: `id`, `direction`, `compartment`, `gpr`, `name`, `equation`, `pathways`
- compounds: `id`, `name`, `formula`, `charge`, `compartment`

`compartment` is derived from the id suffix (`cpd00443_c0` → `c0`).

## Changes

- **new** `lib/utils/modelTsv.ts` — pure `buildReactionsTsv` / `buildCompoundsTsv` /
  `compartmentFromId`, reusing the existing RFC-4180 escaper in `lib/utils/exportCsv.ts`
  (no new escaping code, no new dependency).
- `components/ui/DownloadModelMenu.tsx` — options moved to an exported, typed
  `'api' | 'derived-tsv'` discriminated union; `downloadingFormat` → `downloadingKey`.
  Props interface unchanged, so both call sites (model viewer and My Models) are unaffected.
- `lib/api/modelseed.ts` — doc comment corrected; it still advertised a `'tsv'` format. No
  behaviour change.
- `app/model/[...path]/page.tsx` — helper text updated (one line).

## Tests

- `tests/unit/utils/modelTsv.test.ts` — header rows, compartment derivation, `charge: 0` rendering
  as `0`, commas in reaction names staying unquoted under a tab delimiter, missing optional fields
  keeping the full column count, pathway joining, and the empty-model error paths.
- `tests/unit/components/downloadModelMenuOptions.test.ts` — **the regression test that would have
  caught this**: asserts every API-backed menu entry requests a format inside the backend's
  documented set `['json','sbml','cobrapy']`, and that nothing requests `tsv` from the API.

Fixture shapes were taken from the reporter's own `DC1RawModel.json`, i.e. real production
`format=json` output.

## Verification

All green locally, mirroring `.github/workflows/ci.yml`:

- `npm run lint` — 0 errors (16 pre-existing warnings, none in changed files)
- `npx tsc --noEmit` — clean
- `npm run test:run` — 18 files, **145 tests passed** (+18 new)
- `npm run build` — compiled successfully, 31/31 static pages
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities

## Notes for review

- **No version or CHANGELOG changes** in this PR — deliberate; versioning is decided when
  `staging` is promoted to `master`.
- `format=cobrapy` is documented by the API but was **not** added to the menu, because it could not
  be verified end-to-end without an auth token, and shipping an unverified format is exactly the
  bug this PR fixes. Easy follow-up once someone confirms it works.
- The remaining part of #221 ("reconstruction service unavailable", and native server-side
  TSV/cpdtbl export) is a backend concern for `modelseed-api`, not this repo.
- Branched from `staging`; kept separate from the still-open #227 so the two can be reviewed
  independently.